### PR TITLE
Listen on both ipv4 and ipv6 addresses

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func newAutocertManager(cfg config.Autocert) *autocert.Manager {
 }
 
 func newListener(listenAddr string) net.Listener {
-	ln, err := net.Listen("tcp4", listenAddr)
+	ln, err := net.Listen("tcp", listenAddr)
 	if err != nil {
 		log.Fatalf("cannot listen for %q: %s", listenAddr, err)
 	}


### PR DESCRIPTION
I missunderstand why chproxy use tcp4 for listening, so fix it