### PR TITLE
Add identical concurrent queries handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,13 @@ users:
     # By default requests wait for up to 10 seconds in the queue.
     max_queue_time: 35s
 
+    # Whether to detect identical concurrent queries and run one query at time. 
+    # All identical queries will decrease queue by only 1 in case if `max_queue_size` defined
+    # Make sense when cache enabled
+    #
+    # By default its false
+    detect_identical_concurrent_queries: false
+
   - name: "default"
     to_cluster: "second cluster"
     to_user: "default"

--- a/config/config.go
+++ b/config/config.go
@@ -480,6 +480,12 @@ type User struct {
 	// if omitted or zero - no limits would be applied
 	MaxExecutionTime Duration `yaml:"max_execution_time,omitempty"`
 
+	// Detect all identical concurrently running queries for user
+	// put them to virtual queue and look at that queue as one query
+	// make sense when cache is enable
+	// if omitted or false - joining will not happens
+	DetectIdenticalConcurrentQueries bool `yaml:"detect_identical_concurrent_queries,omitempty"`
+
 	// Maximum number of requests per minute for user
 	// if omitted or zero - no limits would be applied
 	ReqPerMin uint32 `yaml:"requests_per_minute,omitempty"`

--- a/proxy.go
+++ b/proxy.go
@@ -67,6 +67,7 @@ func (rp *reverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		q := getQuerySnippet(req)
 		err = fmt.Errorf("%s: %s; query: %q", s, err, q)
 		respondWith(rw, err, http.StatusTooManyRequests)
+		s.user.clusterQueryCounter.Dec(s)
 		return
 	}
 	defer s.dec()

--- a/proxy.go
+++ b/proxy.go
@@ -67,7 +67,7 @@ func (rp *reverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		q := getQuerySnippet(req)
 		err = fmt.Errorf("%s: %s; query: %q", s, err, q)
 		respondWith(rw, err, http.StatusTooManyRequests)
-		s.user.clusterQueryCounter.Dec(s)
+		s.user.identicalQueryCounter.Dec(s)
 		return
 	}
 	defer s.dec()

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -167,7 +167,7 @@ func TestReverseProxy_ServeHTTP1(t *testing.T) {
 			expStatusCode: http.StatusTooManyRequests,
 			f: func(p *reverseProxy) *http.Response {
 				p.clusters["cluster"].users["web"].maxConcurrentQueries = 1
-				go makeHeavyRequest(p, time.Millisecond*20)
+				go makeHeavyRequest(p, time.Millisecond*200)
 				time.Sleep(time.Millisecond * 10)
 				return makeRequest(p)
 			},
@@ -211,9 +211,26 @@ func TestReverseProxy_ServeHTTP1(t *testing.T) {
 			expStatusCode: http.StatusTooManyRequests,
 			f: func(p *reverseProxy) *http.Response {
 				p.users["default"].maxConcurrentQueries = 1
-				go makeHeavyRequest(p, time.Millisecond*20)
+				go makeHeavyRequest(p, time.Millisecond*200)
 				time.Sleep(time.Millisecond * 10)
 				return makeRequest(p)
+			},
+		},
+		{
+			cfg:           goodCfg,
+			name:          "identical concurrent queries for user",
+			expResponse:   "1\n\n",
+			expStatusCode: http.StatusOK,
+			f: func(p *reverseProxy) *http.Response {
+				p.users["default"].detectIdenticalConcurrentQueries = true
+				p.users["default"].queueCh = make(chan struct{}, 1)
+				go makeHeavyRequest(p, time.Millisecond*200)
+				time.Sleep(time.Millisecond * 10)
+				go makeHeavyRequest(p, time.Millisecond*200)
+				time.Sleep(time.Millisecond * 10)
+				go makeHeavyRequest(p, time.Millisecond*200)
+				time.Sleep(time.Millisecond * 10)
+				return makeHeavyRequest(p, time.Millisecond*200)
 			},
 		},
 		{
@@ -250,11 +267,11 @@ func TestReverseProxy_ServeHTTP1(t *testing.T) {
 			f: func(p *reverseProxy) *http.Response {
 				p.users["default"].maxConcurrentQueries = 1
 				p.users["default"].queueCh = make(chan struct{}, 1)
-				go makeHeavyRequest(p, time.Millisecond*20)
+				go makeHeavyRequest(p, time.Millisecond*200)
 				time.Sleep(time.Millisecond * 5)
-				go makeHeavyRequest(p, time.Millisecond*20)
+				go makeHeavyRequest(p, time.Millisecond*200)
 				time.Sleep(time.Millisecond * 5)
-				return makeHeavyRequest(p, time.Millisecond*20)
+				return makeHeavyRequest(p, time.Millisecond*200)
 			},
 		},
 		{


### PR DESCRIPTION
Sometimes user will send the same heavy query to CH multiple times in a row, however he able to do some other query at the same time - in case if user is Grafana/Metabase/etc.
So to handle this kind of situation solutions is:

- detect identical concurrent queries per user
- send them in virtual queue until first one running on CH
- after first query returned to client, send result of another ones to user from cache
- as a bonus, all these identical queries will take only 1 place in a queue - if `max_queue_size` defined in config