### PR TITLE
fix cannot reach chhost bug

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -47,21 +46,6 @@ func newReverseProxy() *reverseProxy {
 			ErrorHandler: func(rw http.ResponseWriter, req *http.Request, err error) {
 				log.Errorf("http: proxy error: %v", err)
 				rw.WriteHeader(http.StatusBadGateway)
-			},
-
-			Transport: &http.Transport {
-				DisableKeepAlives: true,
-				Proxy: http.ProxyFromEnvironment,
-				DialContext: (&net.Dialer{
-					Timeout:   30 * time.Second,
-					KeepAlive: 30 * time.Second,
-					DualStack: true,
-				}).DialContext,
-				ForceAttemptHTTP2:     true,
-				MaxIdleConns:          100,
-				IdleConnTimeout:       90 * time.Second,
-				TLSHandshakeTimeout:   10 * time.Second,
-				ExpectContinueTimeout: 1 * time.Second,
 			},
 		},
 		reloadSignal: make(chan struct{}),


### PR DESCRIPTION
1、print http transport error log information
2、close chproxy KeepAlive. The CH socket is closed over time, but the CHProxy connection is reused, causing the connection to reset by peer
fix this problem：https://github.com/Vertamedia/chproxy/issues/92