### PR TITLE
support for log rotate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /chproxy
 /tags
+chproxy-*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,12 @@ clean:
 
 release-build:
 	@echo "Ver: $(BUILD_TAG), OPTS: $(BUILD_OPTS)"
-	GOOS=linux GOARCH=amd64 go build $(BUILD_OPTS)
-	rm chproxy-linux-amd64-*.tar.gz
+	GOOS=linux GOARCH=amd64 
+	go build $(BUILD_OPTS)
+	rm -rf chproxy-linux-amd64-*.tar.gz
 	tar czf chproxy-linux-amd64-$(BUILD_TAG).tar.gz chproxy
 
-release: format lint test clean release-build
+release: format test clean release-build
 	@echo "Ver: $(BUILD_TAG), OPTS: $(BUILD_OPTS)"
 	tar czf chproxy-linux-amd64-$(BUILD_TAG).tar.gz chproxy
 

--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,8 @@ type Config struct {
 	// Whether to print debug logs
 	LogDebug bool `yaml:"log_debug,omitempty"`
 
+	LogRotates LogRotate `yaml:"log_rotate,omitempty"`
+
 	// Whether to ignore security warnings
 	HackMePlease bool `yaml:"hack_me_please,omitempty"`
 
@@ -133,6 +135,38 @@ type Server struct {
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (s *Server) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type plain Server
+	if err := unmarshal((*plain)(s)); err != nil {
+		return err
+	}
+	return checkOverflow(s.XXX, "server")
+}
+
+type LogRotate struct {
+	//filename = path/logfile
+	Filename 	string `yaml:"filename,omitempty"`
+
+	//megabytes for MB, It defaults to 100 megabytes.
+	MaxSize 	int `yaml:"maxSize,omitempty"`
+
+	// max backups, The default is not to remove old log files
+	// based on age.
+	MaxBackups 	int `yaml:"maxBackups,omitempty"`
+
+	// days, The default
+	// is to retain all old log files (though MaxAge may still cause them to get
+	// deleted.)
+	MaxAge 		int `yaml:"maxAge,omitempty"`
+
+	// compress gz, The default is not to perform compression.
+	Compress 	bool `yaml:"compress,omitempty"`
+
+	// Catches all undefined fields and must be empty after parsing.
+	XXX map[string]interface{} `yaml:",inline"`
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (s *LogRotate) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type plain LogRotate
 	if err := unmarshal((*plain)(s)); err != nil {
 		return err
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -62,6 +62,13 @@ func TestLoadConfig(t *testing.T) {
 					},
 				},
 				LogDebug: true,
+				LogRotates: LogRotate{
+					Filename: "logpath/test.log",
+					MaxSize: 1,
+					MaxBackups: 2,
+					MaxAge: 1,
+					Compress: true,
+				},
 
 				Clusters: []Cluster{
 					{

--- a/config/examples/simple.yml
+++ b/config/examples/simple.yml
@@ -1,3 +1,7 @@
+log_rotate:
+  # filename = path/logfile
+  filename: "logpath/test.log"
+
 server:
   http:
       listen_addr: ":9090"

--- a/config/testdata/full.yml
+++ b/config/testdata/full.yml
@@ -3,6 +3,20 @@
 # By default debug logs are disabled.
 log_debug: true
 
+# rotate log file
+log_rotate:
+  # filename = path/logfile
+  filename: "logpath/test.log"
+  # megabytes for MB, megabytes for MB, It defaults to 100 megabytes.
+  maxSize: 1
+  # max backups, The default is not to remove old log files based on age.
+  maxBackups: 2
+  # days, The default is to retain all old log files (though MaxAge may
+  # still cause them to get deleted.)
+  maxAge: 1
+  # compress gz, The default is not to perform compression.
+  compress: true
+
 # Whether to ignore security checks during config parsing.
 #
 # By default security checks are enabled.

--- a/git_push.sh
+++ b/git_push.sh
@@ -7,4 +7,4 @@ fi
 
 git add . 
 git commit -m "$param" 
-git push origin feature-springboot-leomi
+git push origin master

--- a/git_push.sh
+++ b/git_push.sh
@@ -1,0 +1,10 @@
+param=$1
+if [ ! $param ]
+then
+	echo "please enter some message!"
+	exit
+fi
+
+git add . 
+git commit -m "$param" 
+git push origin feature-springboot-leomi

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,13 @@ module github.com/Vertamedia/chproxy
 go 1.13
 
 require (
+	github.com/BurntSushi/toml v0.4.1 // indirect
 	github.com/DataDog/zstd v1.4.4
 	github.com/frankban/quicktest v1.7.2 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/pierrec/lz4 v2.4.0+incompatible
 	github.com/prometheus/client_golang v1.3.0
 	golang.org/x/crypto v0.0.0-20200109152110-61a87790db17
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.2.7
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
+github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/DataDog/zstd v1.4.4 h1:+IawcoXhCBylN7ccwdwf8LOH2jKq7NavGpEPanrlTzE=
 github.com/DataDog/zstd v1.4.4/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -95,6 +97,8 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=

--- a/log/log.go
+++ b/log/log.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"fmt"
+	"gopkg.in/natefinch/lumberjack.v2"
 	"io/ioutil"
 	"log"
 	"os"
@@ -20,6 +21,24 @@ var (
 	// NilLogger suppresses all the log messages.
 	NilLogger = log.New(ioutil.Discard, "", stdLogFlags)
 )
+
+func InitLogger(filename string,maxSize,maxBackups,maxAge int ,compress bool)  {
+	if filename == ""{
+		return
+	}
+	logger := &lumberjack.Logger{
+		Filename:   filename,
+		MaxSize:    maxSize, // megabytes for MB
+		MaxBackups: maxBackups,
+		MaxAge:     maxAge,    // days
+		Compress:   compress, // disabled by default
+	}
+
+	debugLogger = log.New(logger, "DEBUG: ", stdLogFlags)
+	infoLogger  = log.New(logger, "INFO: ", stdLogFlags)
+	errorLogger = log.New(logger, "ERROR: ", stdLogFlags)
+	fatalLogger = log.New(logger, "FATAL: ", stdLogFlags)
+}
 
 // SuppressOutput suppresses all output from logs if `suppress` is true
 // used while testing

--- a/main.go
+++ b/main.go
@@ -40,7 +40,6 @@ func main() {
 		fmt.Printf("%s\n", versionString())
 		os.Exit(0)
 	}
-
 	log.Infof("%s", versionString())
 	log.Infof("Loading config: %s", *configFile)
 	cfg, err := loadConfig()
@@ -268,6 +267,8 @@ func applyConfig(cfg *config.Config) error {
 	allowedNetworksHTTP.Store(&cfg.Server.HTTP.AllowedNetworks)
 	allowedNetworksHTTPS.Store(&cfg.Server.HTTPS.AllowedNetworks)
 	allowedNetworksMetrics.Store(&cfg.Server.Metrics.AllowedNetworks)
+	r:=cfg.LogRotates
+	log.InitLogger(r.Filename,r.MaxSize,r.MaxBackups,r.MaxAge,r.Compress)
 	log.SetDebug(cfg.LogDebug)
 	log.Infof("Loaded config:\n%s", cfg)
 


### PR DESCRIPTION
Add log rotate using lumberjack.v2. 

#75 

For some internal reasons, the production environment cannot use other methods for log rotation.
So I hope to provide log rotate capability, which can be configured according to the configuration file.

Signed-off-by: yixy <youzhilane01@gmail.com>