### PR TITLE
chore: add golangci linters settings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,64 @@
+run:
+  timeout: 3m
+  tests: false
+
+linters:
+  enable:
+    - asciicheck
+    - bodyclose
+    - depguard
+    - dogsled
+    - dupl
+    - durationcheck
+    - errname
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - forcetypeassert
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - gofumpt
+    - goheader
+    - goimports
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - govet
+    - ifshort
+    - importas
+    - makezero
+    - megacheck
+    - misspell
+    - nakedret
+    - nilerr
+    - predeclared
+    - promlinter
+    - rowserrcheck
+    - sqlclosecheck
+    - testpackage
+    - thelper
+    - tparallel
+    - unconvert
+    - unparam
+    - wastedassign
+    - whitespace
+  disable:
+    # Should be readded in the future with a dedicated PR to do the fix
+    - cyclop
+    - funlen
+    - gocognit
+    - nolintlint
+    - revive
+    - stylecheck
+    - nestif
+
+    # Disabled with a reason
+    - gochecknoglobals # incompatible with the way we define our flags currently
+    - maligned # checker not supported anymore
+    - noctx # disabled because we do not plan to distribute this code as a library
+    - prealloc # we are not after some perf
+    - tagliatelle # disabled because we are dependant on external API that do not follow the right naming

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,15 @@ lint:
 	go vet $(pkgs)
 	go list ./... | grep -v /vendor/ | xargs -n1 golint
 
+tidy:
+	go mod tidy
+
+deps:
+	go mod download
+
+go-lint: deps tidy
+	golangci-lint run -v
+
 reconfigure:
 	kill -HUP `pidof chproxy`
 


### PR DESCRIPTION
Add basic `golangci` linters settings.

Run the following `make go-lint` to execute the golangci lint.

`make go-lint` depends on `go mod download` and `go mod tidy`
