### PR TITLE
Improve handling of concurrent identical queries

### DIFF
--- a/cache/async_cache.go
+++ b/cache/async_cache.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -38,7 +37,7 @@ type TransactionResult struct {
 
 func (c *AsyncCache) AwaitForConcurrentTransaction(key *Key) (TransactionResult, error) {
 	startTime := time.Now()
-	var seenState TransactionState
+	seenState := transactionAbsent
 	for {
 		elapsedTime := time.Since(startTime)
 		if elapsedTime > c.graceTime {
@@ -51,12 +50,6 @@ func (c *AsyncCache) AwaitForConcurrentTransaction(key *Key) (TransactionResult,
 		}
 
 		state, err := c.TransactionRegistry.Status(key)
-		if errors.Is(err, ErrMissingTransaction) {
-			return TransactionResult{
-				ElapsedTime: elapsedTime,
-				State:       state,
-			}, nil
-		}
 
 		if err != nil {
 			return TransactionResult{}, err

--- a/cache/async_cache.go
+++ b/cache/async_cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -9,9 +10,10 @@ import (
 	"github.com/go-redis/redis/v8"
 )
 
-// AsyncCache is a transactional cache allowing the results from concurrent queries.
-// When query A is equal to query B and A arrives no more than defined graceTime, query A will await for the results of query B for the max time equal to:
-// graceTime - (arrivalB - arrivalA)
+// AsyncCache is a transactional cache enabled to serve the results from concurrent queries.
+// When query A and B are equal, and query B arrives after query A with no more than defined deadline interval [[graceTime]],
+// query B will await for the results of query B for the max time equal to:
+// max_awaiting_time = graceTime - (arrivalB - arrivalA)
 type AsyncCache struct {
 	Cache
 	TransactionRegistry
@@ -31,31 +33,43 @@ func (c *AsyncCache) Close() error {
 
 type TransactionResult struct {
 	ElapsedTime time.Duration
-	Completed   bool
+	State       TransactionState
 }
 
-func (c *AsyncCache) AwaitForConcurrentTransaction(key *Key) TransactionResult {
+func (c *AsyncCache) AwaitForConcurrentTransaction(key *Key) (TransactionResult, error) {
 	startTime := time.Now()
-
+	var seenState TransactionState
 	for {
 		elapsedTime := time.Since(startTime)
 		if elapsedTime > c.graceTime {
-			// The entry didn't appear during graceTime.
+			// The entry didn't appear during deadline.
 			// Let the caller creating it.
 			return TransactionResult{
 				ElapsedTime: elapsedTime,
-				Completed:   false,
-			}
+				State:       seenState,
+			}, nil
 		}
 
-		if c.TransactionRegistry.IsDone(key) {
+		state, err := c.TransactionRegistry.Status(key)
+		if errors.Is(err, ErrMissingTransaction) {
 			return TransactionResult{
 				ElapsedTime: elapsedTime,
-				Completed:   true,
-			}
+				State:       state,
+			}, nil
 		}
 
-		// Wait for graceTime in the hope the entry will appear
+		if err != nil {
+			return TransactionResult{}, err
+		}
+
+		if !state.IsPending() {
+			return TransactionResult{
+				ElapsedTime: elapsedTime,
+				State:       state,
+			}, nil
+		}
+
+		// Wait for deadline in the hope the entry will appear
 		// in the cache.
 		//
 		// This should protect from thundering herd problem when
@@ -82,11 +96,13 @@ func NewAsyncCache(cfg config.Cache) (*AsyncCache, error) {
 	var cache Cache
 	var transaction TransactionRegistry
 	var err error
+	// transaction will be kept until we're sure there's no possible concurrent query running
+	transactionDeadline := 2 * graceTime
 
 	switch cfg.Mode {
 	case "file_system":
 		cache, err = newFilesSystemCache(cfg, graceTime)
-		transaction = newInMemoryTransactionRegistry(graceTime)
+		transaction = newInMemoryTransactionRegistry(transactionDeadline)
 	case "redis":
 		var redisClient redis.UniversalClient
 		redisClient, err = clients.NewRedisClient(cfg.Redis)

--- a/cache/async_cache.go
+++ b/cache/async_cache.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/contentsquare/chproxy/log"
+
 	"github.com/contentsquare/chproxy/clients"
 	"github.com/contentsquare/chproxy/config"
 	"github.com/go-redis/redis/v8"
@@ -75,11 +77,14 @@ func (c *AsyncCache) AwaitForConcurrentTransaction(key *Key) (TransactionResult,
 	}
 }
 
-func NewAsyncCache(cfg config.Cache) (*AsyncCache, error) {
+func NewAsyncCache(cfg config.Cache, maxExecutionTime time.Duration) (*AsyncCache, error) {
 	graceTime := time.Duration(cfg.GraceTime)
+	if graceTime > 0 {
+		log.Errorf("[DEPRECATED] detected grace time configuration %s. It will be removed in the new version", graceTime)
+	}
 	if graceTime == 0 {
 		// Default grace time.
-		graceTime = 5 * time.Second
+		graceTime = maxExecutionTime
 	}
 	if graceTime < 0 {
 		// Disable protection from `dogpile effect`.

--- a/cache/async_cache_test.go
+++ b/cache/async_cache_test.go
@@ -63,12 +63,12 @@ func TestAsyncCache_AwaitForConcurrentTransaction_GraceTimeWithoutTransactionCom
 	}
 
 	startTime := time.Now()
-	done := asyncCache.AwaitForConcurrentTransaction(key)
+	transactionResult := asyncCache.AwaitForConcurrentTransaction(key)
 	elapsedTime := time.Since(startTime)
 
 	// in order to let the cleaner swipe the transaction
 	time.Sleep(100 * time.Millisecond)
-	if done == asyncCache.IsDone(key) && done {
+	if transactionResult.Completed == asyncCache.IsDone(key) && transactionResult.Completed {
 		t.Fatalf("unexpected behaviour: transaction awaiting time elapsed %s", elapsedTime.String())
 	}
 
@@ -99,7 +99,7 @@ func TestAsyncCache_AwaitForConcurrentTransaction_TransactionCompletedWhileAwait
 	}()
 
 	startTime := time.Now()
-	done := asyncCache.AwaitForConcurrentTransaction(key)
+	transactionResult := asyncCache.AwaitForConcurrentTransaction(key)
 	elapsedTime := time.Since(startTime)
 
 	err := <-errs
@@ -107,7 +107,7 @@ func TestAsyncCache_AwaitForConcurrentTransaction_TransactionCompletedWhileAwait
 		t.Fatalf("unexpected error: %s failed to unregister transaction", err)
 	}
 
-	if done != asyncCache.IsDone(key) || !done || elapsedTime >= graceTime {
+	if transactionResult.Completed != asyncCache.IsDone(key) || !transactionResult.Completed || elapsedTime >= graceTime {
 		t.Fatalf("unexpected behaviour: transaction awaiting time elapsed %s", elapsedTime.String())
 	}
 

--- a/cache/async_cache_test.go
+++ b/cache/async_cache_test.go
@@ -119,7 +119,7 @@ func TestAsyncCache_AwaitForConcurrentTransaction_TransactionCompletedWhileAwait
 	}()
 
 	startTime := time.Now()
-	transactionResult, err := asyncCache.AwaitForConcurrentTransaction(key)
+	transactionState, err := asyncCache.AwaitForConcurrentTransaction(key)
 	if err != nil {
 		t.Fatalf("unexpected error: %s failed to unregister transaction", err)
 	}
@@ -131,7 +131,7 @@ func TestAsyncCache_AwaitForConcurrentTransaction_TransactionCompletedWhileAwait
 		t.Fatalf("unexpected error: %s failed to unregister transaction", err)
 	}
 
-	if !transactionResult.State.IsCompleted() || elapsedTime >= graceTime {
+	if !transactionState.IsCompleted() || elapsedTime >= graceTime {
 		t.Fatalf("unexpected behaviour: transaction awaiting time elapsed %s", elapsedTime.String())
 	}
 }
@@ -164,7 +164,7 @@ func TestAsyncCache_AwaitForConcurrentTransaction_TransactionFailedWhileAwaiting
 	}()
 
 	startTime := time.Now()
-	transactionResult, err := asyncCache.AwaitForConcurrentTransaction(key)
+	transactionState, err := asyncCache.AwaitForConcurrentTransaction(key)
 	if err != nil {
 		t.Fatalf("unexpected error: %s failed to unregister transaction", err)
 	}
@@ -176,7 +176,7 @@ func TestAsyncCache_AwaitForConcurrentTransaction_TransactionFailedWhileAwaiting
 		t.Fatalf("unexpected error: %s failed to unregister transaction", err)
 	}
 
-	if !transactionResult.State.IsFailed() || elapsedTime >= graceTime {
+	if !transactionState.IsFailed() || elapsedTime >= graceTime {
 		t.Fatalf("unexpected behaviour: transaction awaiting time elapsed %s", elapsedTime.String())
 	}
 }

--- a/cache/async_cache_test.go
+++ b/cache/async_cache_test.go
@@ -218,7 +218,7 @@ func TestAsyncCache_FilesystemCache_instantiation(t *testing.T) {
 	if err := os.RemoveAll(testDirAsync); err != nil {
 		log.Fatalf("cannot remove %q: %s", testDirAsync, err)
 	}
-	_, err := NewAsyncCache(fileSystemCfg)
+	_, err := NewAsyncCache(fileSystemCfg, 1*time.Second)
 	if err != nil {
 		t.Fatalf("could not instanciate filsystem async cache because of the following error: %s", err)
 	}
@@ -234,7 +234,7 @@ func TestAsyncCache_FilesystemCache_wrong_instantiation(t *testing.T) {
 		},
 		Expire: config.Duration(time.Minute),
 	}
-	_, err := NewAsyncCache(fileSystemCfg)
+	_, err := NewAsyncCache(fileSystemCfg, 1*time.Second)
 	if err == nil {
 		t.Fatalf("the instanciate of filsystem async cache should have crashed")
 	}
@@ -251,7 +251,7 @@ func TestAsyncCache_RedisCache_instantiation(t *testing.T) {
 		Expire: config.Duration(cacheTTL),
 	}
 
-	_, err := NewAsyncCache(redisCfg)
+	_, err := NewAsyncCache(redisCfg, 1*time.Second)
 	if err != nil {
 		t.Fatalf("could not instanciate redis async cache because of the following error: %s", err)
 	}
@@ -267,13 +267,13 @@ func TestAsyncCache_RedisCache_wrong_instantiation(t *testing.T) {
 		},
 	}
 
-	_, err := NewAsyncCache(redisCfg)
+	_, err := NewAsyncCache(redisCfg, 1*time.Second)
 	if err == nil {
 		t.Fatalf("the redis instanciation should have crashed")
 	}
 }
 
-func TestAsyncCache_Unkown_instantiation(t *testing.T) {
+func TestAsyncCache_Unknown_instantiation(t *testing.T) {
 	var redisCfg = config.Cache{
 		Name:   "test",
 		Mode:   "Unkown Mode",
@@ -281,7 +281,7 @@ func TestAsyncCache_Unkown_instantiation(t *testing.T) {
 		Expire: config.Duration(cacheTTL),
 	}
 
-	_, err := NewAsyncCache(redisCfg)
+	_, err := NewAsyncCache(redisCfg, 1*time.Second)
 	if err == nil {
 		t.Fatalf("The instanciation should have crash")
 	}

--- a/cache/filesystem_cache.go
+++ b/cache/filesystem_cache.go
@@ -115,7 +115,7 @@ func (f *fileSystemCache) Get(key *Key) (*CachedData, error) {
 			return nil, ErrMissing
 		}
 		// Serve expired file in the hope it will be substituted
-		// with the fresh file during graceTime.
+		// with the fresh file during deadline.
 	}
 
 	b, err := ioutil.ReadAll(file)
@@ -242,7 +242,7 @@ func (f *fileSystemCache) clean() {
 
 	log.Debugf("cache %q: start cleaning dir %q", f.Name(), f.dir)
 
-	// Remove cached files after a graceTime from their expiration,
+	// Remove cached files after a deadline from their expiration,
 	// so they may be served until they are substituted with fresh files.
 	expire := f.expire + f.grace
 

--- a/cache/redis_cache.go
+++ b/cache/redis_cache.go
@@ -97,7 +97,7 @@ func (r *redisCache) Get(key *Key) (*CachedData, error) {
 	val, err := r.client.Get(ctx, key.String()).Result()
 
 	// if key not found in cache
-	if errors.Is(err, redis.Nil) || val == pendingTransactionVal {
+	if errors.Is(err, redis.Nil)  {
 		return nil, ErrMissing
 	}
 

--- a/cache/redis_cache.go
+++ b/cache/redis_cache.go
@@ -97,7 +97,7 @@ func (r *redisCache) Get(key *Key) (*CachedData, error) {
 	val, err := r.client.Get(ctx, key.String()).Result()
 
 	// if key not found in cache
-	if errors.Is(err, redis.Nil)  {
+	if errors.Is(err, redis.Nil) {
 		return nil, ErrMissing
 	}
 

--- a/cache/transaction_registry.go
+++ b/cache/transaction_registry.go
@@ -30,7 +30,15 @@ const (
 	transactionCreated   TransactionState = 0
 	transactionCompleted TransactionState = 1
 	transactionFailed    TransactionState = 2
+	transactionAbsent    TransactionState = 3
 )
+
+func (t *TransactionState) IsAbsent() bool {
+	if t != nil {
+		return *t == transactionAbsent
+	}
+	return false
+}
 
 func (t *TransactionState) IsFailed() bool {
 	if t != nil {

--- a/cache/transaction_registry.go
+++ b/cache/transaction_registry.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"errors"
 	"io"
 )
 
@@ -21,8 +20,6 @@ type TransactionRegistry interface {
 	// Status checks the status of the transaction
 	Status(key *Key) (TransactionState, error)
 }
-
-var ErrMissingTransaction = errors.New("missing entry in transaction registry")
 
 type TransactionState uint64
 

--- a/cache/transaction_registry.go
+++ b/cache/transaction_registry.go
@@ -1,15 +1,54 @@
 package cache
 
-import "io"
+import (
+	"errors"
+	"io"
+)
 
 // TransactionRegistry is a registry of ongoing queries identified by Key.
 type TransactionRegistry interface {
 	io.Closer
 
-	// Register creates a new transaction record
-	Register(key *Key) error
-	// Unregister removes a transaction record
-	Unregister(key *Key) error
-	// IsDone checks the status of a transaction
-	IsDone(key *Key) bool
+	// Create creates a new transaction record
+	Create(key *Key) error
+
+	// Complete completes a transaction for given key
+	Complete(key *Key) error
+
+	// Fail fails a transaction for given key
+	Fail(key *Key) error
+
+	// Status checks the status of the transaction
+	Status(key *Key) (TransactionState, error)
+}
+
+var ErrMissingTransaction = errors.New("missing entry in transaction registry")
+
+type TransactionState uint64
+
+const (
+	transactionCreated   TransactionState = 0
+	transactionCompleted TransactionState = 1
+	transactionFailed    TransactionState = 2
+)
+
+func (t *TransactionState) IsFailed() bool {
+	if t != nil {
+		return *t == transactionFailed
+	}
+	return false
+}
+
+func (t *TransactionState) IsCompleted() bool {
+	if t != nil {
+		return *t == transactionCompleted
+	}
+	return false
+}
+
+func (t *TransactionState) IsPending() bool {
+	if t != nil {
+		return *t == transactionCreated
+	}
+	return false
 }

--- a/cache/transaction_registry_inmem.go
+++ b/cache/transaction_registry_inmem.go
@@ -87,7 +87,7 @@ func (i *inMemoryTransactionRegistry) Status(key *Key) (TransactionState, error)
 	if entry, ok := i.pendingEntries[k]; ok {
 		return entry.state, nil
 	}
-	return transactionCompleted, ErrMissingTransaction
+	return transactionAbsent, nil
 }
 
 func (i *inMemoryTransactionRegistry) Close() error {

--- a/cache/transaction_registry_redis.go
+++ b/cache/transaction_registry_redis.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"fmt"
+
 	"github.com/contentsquare/chproxy/log"
 	"github.com/go-redis/redis/v8"
 )
@@ -24,7 +25,7 @@ func newRedisTransactionRegistry(redisClient redis.UniversalClient, deadline tim
 }
 
 func (r *redisTransactionRegistry) Create(key *Key) error {
-	return r.redisClient.Set(context.Background(), toTransactionKey(key), transactionCreated, r.deadline).Err()
+	return r.redisClient.Set(context.Background(), toTransactionKey(key), uint64(transactionCreated), r.deadline).Err()
 }
 
 func (r *redisTransactionRegistry) Complete(key *Key) error {
@@ -36,7 +37,7 @@ func (r *redisTransactionRegistry) Fail(key *Key) error {
 }
 
 func (r *redisTransactionRegistry) updateTransactionState(key *Key, state TransactionState) error {
-	return r.redisClient.Set(context.Background(), toTransactionKey(key), state, redis.KeepTTL).Err()
+	return r.redisClient.Set(context.Background(), toTransactionKey(key), uint64(state), redis.KeepTTL).Err()
 }
 
 func (r *redisTransactionRegistry) Status(key *Key) (TransactionState, error) {

--- a/cache/transaction_registry_redis.go
+++ b/cache/transaction_registry_redis.go
@@ -43,12 +43,12 @@ func (r *redisTransactionRegistry) updateTransactionState(key *Key, state Transa
 func (r *redisTransactionRegistry) Status(key *Key) (TransactionState, error) {
 	state, err := r.redisClient.Get(context.Background(), toTransactionKey(key)).Uint64()
 	if errors.Is(err, redis.Nil) {
-		return transactionCompleted, ErrMissingTransaction
+		return transactionAbsent, nil
 	}
 
 	if err != nil {
 		log.Errorf("Failed to fetch transaction status from redis for key: %s", key.String())
-		return transactionCompleted, ErrMissingTransaction
+		return transactionAbsent, err
 	}
 
 	return TransactionState(state), nil

--- a/cache/transaction_registry_redis.go
+++ b/cache/transaction_registry_redis.go
@@ -28,11 +28,15 @@ func (r *redisTransactionRegistry) Create(key *Key) error {
 }
 
 func (r *redisTransactionRegistry) Complete(key *Key) error {
-	return r.redisClient.Set(context.Background(), toTransactionKey(key), transactionCompleted, redis.KeepTTL).Err()
+	return r.updateTransactionState(key, transactionCompleted)
 }
 
 func (r *redisTransactionRegistry) Fail(key *Key) error {
-	return r.redisClient.Set(context.Background(), toTransactionKey(key), transactionFailed, redis.KeepTTL).Err()
+	return r.updateTransactionState(key, transactionFailed)
+}
+
+func (r *redisTransactionRegistry) updateTransactionState(key *Key, state TransactionState) error {
+	return r.redisClient.Set(context.Background(), toTransactionKey(key), state, redis.KeepTTL).Err()
 }
 
 func (r *redisTransactionRegistry) Status(key *Key) (TransactionState, error) {

--- a/cache/transaction_registry_redis_test.go
+++ b/cache/transaction_registry_redis_test.go
@@ -22,22 +22,21 @@ func TestRedisTransaction(t *testing.T) {
 
 	redisTransaction := newRedisTransactionRegistry(redisClient, graceTime)
 
-	if err := redisTransaction.Register(key); err != nil {
+	if err := redisTransaction.Create(key); err != nil {
 		t.Fatalf("unexpected error: %s while registering new transaction", err)
 	}
 
-	isDone := redisTransaction.IsDone(key)
-	if isDone {
+	status, err := redisTransaction.Status(key)
+	if err != nil || !status.IsPending() {
 		t.Fatalf("unexpected: transaction should be pending")
 	}
 
-	if err := redisTransaction.Unregister(key); err != nil {
+	if err := redisTransaction.Complete(key); err != nil {
 		t.Fatalf("unexpected error: %s while unregistering transaction", err)
 	}
 
-	isDone = redisTransaction.IsDone(key)
-	if !isDone {
+	status, err = redisTransaction.Status(key)
+	if err != nil || !status.IsCompleted() {
 		t.Fatalf("unexpected: transaction should be done")
 	}
-
 }

--- a/cache/transaction_registry_test.go
+++ b/cache/transaction_registry_test.go
@@ -12,21 +12,21 @@ func TestInMemoryTransaction(t *testing.T) {
 	}
 	inMemoryTransaction := newInMemoryTransactionRegistry(graceTime)
 
-	if err := inMemoryTransaction.Register(key); err != nil {
+	if err := inMemoryTransaction.Create(key); err != nil {
 		t.Fatalf("unexpected error: %s while registering new transaction", err)
 	}
 
-	isDone := inMemoryTransaction.IsDone(key)
-	if isDone {
+	status, err := inMemoryTransaction.Status(key)
+	if err != nil || !status.IsPending() {
 		t.Fatalf("unexpected: transaction should be pending")
 	}
 
-	if err := inMemoryTransaction.Unregister(key); err != nil {
+	if err := inMemoryTransaction.Complete(key); err != nil {
 		t.Fatalf("unexpected error: %s while unregistering transaction", err)
 	}
 
-	isDone = inMemoryTransaction.IsDone(key)
-	if !isDone {
+	status, err = inMemoryTransaction.Status(key)
+	if err != nil || !status.IsCompleted() {
 		t.Fatalf("unexpected: transaction should be done")
 	}
 

--- a/config/README.md
+++ b/config/README.md
@@ -68,6 +68,8 @@ file_system:
 # Expiration time for cached responses.
 expire: <duration>
 
+# DEPRECATED: default value equal to `max_execution_time` should be used. 
+#             New configuration parameter will be provided to disable the protection at will. 
 # When multiple requests with identical query simultaneously hit `chproxy`
 # and there is no cached response for the query, then only a single
 # request will be proxied to clickhouse. Other requests will wait
@@ -99,6 +101,8 @@ redis:
 # Expiration time for cached responses.
 expire: <duration>
 
+# DEPRECATED: default value equal to `max_execution_time` should be used. 
+#             New configuration parameter will be provided to disable the protection at will. 
 # When multiple requests with identical query simultaneously hit `chproxy`
 # and there is no cached response for the query, then only a single
 # request will be proxied to clickhouse. Other requests will wait

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,8 @@ var (
 		Request:  "/?query=SELECT%201",
 		Response: "1\n",
 	}
+
+	defaultExecutionTime = Duration(30 * time.Second)
 )
 
 // Config describes server configuration, access and proxy rules
@@ -596,7 +598,9 @@ type Cache struct {
 	// on new request and re-cached
 	Expire Duration `yaml:"expire,omitempty"`
 
-	// Grace duration before the expired entry is deleted from the cache.
+	// Deprecated: GraceTime duration before the expired entry is deleted from the cache.
+	// It's deprecated and in future versions it'll be replaced by user's MaxExecutionTime.
+	// It's already the case today if value of GraceTime is omitted.
 	GraceTime Duration `yaml:"grace_time,omitempty"`
 
 	FileSystem FileSystemCacheConfig `yaml:"file_system,omitempty"`
@@ -803,6 +807,10 @@ func LoadFile(filename string) (*Config, error) {
 	}
 	for i := range cfg.Users {
 		u := &cfg.Users[i]
+		if u.MaxExecutionTime == 0 {
+			u.MaxExecutionTime = defaultExecutionTime
+		}
+
 		ud := time.Duration(u.MaxExecutionTime + u.MaxQueueTime)
 		if ud > maxResponseTime {
 			maxResponseTime = ud

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -187,6 +187,7 @@ var fullConfig = Config{
 			ReqPerMin:    4,
 			MaxQueueSize: 100,
 			MaxQueueTime: Duration(35 * time.Second),
+			MaxExecutionTime: Duration(30 * time.Second),
 			Cache:        "longterm",
 			Params:       "web",
 		},
@@ -249,7 +250,7 @@ func TestLoadConfig(t *testing.T) {
 						NetworksOrGroups: []string{"127.0.0.1"},
 						TimeoutCfg: TimeoutCfg{
 							ReadTimeout:  Duration(time.Minute),
-							WriteTimeout: Duration(time.Minute),
+							WriteTimeout: Duration(90 * time.Second),
 							IdleTimeout:  Duration(10 * time.Minute),
 						},
 					},
@@ -277,6 +278,7 @@ func TestLoadConfig(t *testing.T) {
 						Name:      "default",
 						ToCluster: "cluster",
 						ToUser:    "default",
+						MaxExecutionTime: Duration(30 * time.Second),
 					},
 				},
 			},
@@ -606,7 +608,7 @@ func TestConfigTimeouts(t *testing.T) {
 			"testdata/default_values.yml",
 			TimeoutCfg{
 				ReadTimeout:  Duration(time.Minute),
-				WriteTimeout: Duration(time.Minute),
+				WriteTimeout: Duration(90 * time.Second), // defaultExecutionTime + 1 min
 				IdleTimeout:  Duration(10 * time.Minute),
 			},
 		},
@@ -789,6 +791,7 @@ users:
   password: XXX
   to_cluster: first cluster
   to_user: web
+  max_execution_time: 30s
   requests_per_minute: 4
   max_queue_size: 100
   max_queue_time: 35s

--- a/docs/content/en/configuration/default.md
+++ b/docs/content/en/configuration/default.md
@@ -44,6 +44,8 @@ caches:
     # Expiration time for cached responses.
     expire: 1h
 
+    # DEPRECATED: default value equal to `max_execution_time` should be used. 
+    #             New configuration parameter will be provided to disable the protection at will. 
     # When multiple requests with identical query simultaneously hit `chproxy`
     # and there is no cached response for the query, then only a single
     # request will be proxied to clickhouse. Other requests will wait

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DataDog/zstd v1.5.0
 	github.com/alicebob/miniredis/v2 v2.18.0
 	github.com/go-redis/redis/v8 v8.11.4
-	github.com/google/go-cmp v0.5.7 // indirect
+	github.com/google/go-cmp v0.5.7
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/pierrec/lz4 v2.4.0+incompatible
 	github.com/prometheus/client_golang v1.3.0
@@ -29,5 +29,6 @@ require (
 	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 // indirect
 	golang.org/x/sys v0.0.0-20210423082822-04245dca01da // indirect
 	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/pierrec/lz4 v2.4.0+incompatible
 	github.com/prometheus/client_golang v1.3.0
+	github.com/stretchr/testify v1.7.1
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -18,10 +19,12 @@ require (
 	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/frankban/quicktest v1.7.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.1.0 // indirect
 	github.com/prometheus/common v0.7.0 // indirect
 	github.com/prometheus/procfs v0.0.8 // indirect
@@ -31,4 +34,5 @@ require (
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,7 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
@@ -91,6 +92,7 @@ github.com/pierrec/lz4 v2.4.0+incompatible h1:06usnXXDNcPvCHDkmPpkidf4jTc52UKld7
 github.com/pierrec/lz4 v2.4.0+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
@@ -114,6 +116,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da h1:NimzV1aGyq29m5ukMK0AMWEhFaL/lrEOaephfuoiARg=
 github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da/go.mod h1:E1AXubJBdNmFERAOucpDIxNzeGfLzg0mYh+UfMWdChA=
@@ -189,3 +193,5 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a h1:HbKu58rmZpUGpz5+4FfNmIU+FmZg2P3Xaj2v2bfNWmk=
 github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
-github.com/alicebob/miniredis/v2 v2.16.0 h1:ALkyFg7bSTEd1Mkrb4ppq4fnwjklA59dVtIehXCUZkU=
-github.com/alicebob/miniredis/v2 v2.16.0/go.mod h1:gquAfGbzn92jvtrSC69+6zZnwSODVXVpYDRaGhWaL6I=
 github.com/alicebob/miniredis/v2 v2.18.0 h1:EPUGD69ou4Uw4c81t9NLh0+dSou46k4tFEvf498FJ0g=
 github.com/alicebob/miniredis/v2 v2.18.0/go.mod h1:gquAfGbzn92jvtrSC69+6zZnwSODVXVpYDRaGhWaL6I=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -54,7 +52,6 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 
 	registerMetrics()
 
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGHUP)
 	go func() {
 		for {

--- a/main_test.go
+++ b/main_test.go
@@ -15,6 +15,8 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -91,7 +93,7 @@ func TestServe(t *testing.T) {
 				if resp.StatusCode != http.StatusOK {
 					t.Fatalf("unexpected status code: %d; expected: %d", resp.StatusCode, http.StatusOK)
 				}
-				checkHttpResponse(t, resp, expectedOkResp)
+				checkResponse(t, resp.Body, expectedOkResp)
 
 				// check cached response
 				key := &cache.Key{
@@ -351,9 +353,9 @@ func TestServe(t *testing.T) {
 				checkErr(t, err)
 
 				resp := httpRequest(t, req, http.StatusOK)
-				checkHttpResponse(t, resp, expectedOkResp)
+				checkResponse(t, resp.Body, expectedOkResp)
 				resp2 := httpRequest(t, req, http.StatusOK)
-				checkHttpResponse(t, resp2, expectedOkResp)
+				checkResponse(t, resp2.Body, expectedOkResp)
 				keys := redisClient.Keys()
 				if len(keys) != 1 {
 					t.Fatalf("unexpected amount of keys in redis: %v", len(keys))
@@ -389,10 +391,10 @@ func TestServe(t *testing.T) {
 				checkErr(t, err)
 
 				resp := httpRequest(t, req, http.StatusOK)
-				checkHttpResponse(t, resp, string(bytesWithInvalidUTFPairs))
+				checkResponse(t, resp.Body, string(bytesWithInvalidUTFPairs))
 				resp2 := httpRequest(t, req, http.StatusOK)
 				// if we do not use base64 to encode/decode the cached payload, EOF error will be thrown here.
-				checkHttpResponse(t, resp2, string(bytesWithInvalidUTFPairs))
+				checkResponse(t, resp2.Body, string(bytesWithInvalidUTFPairs))
 				keys := redisClient.Keys()
 				if len(keys) != 1 {
 					t.Fatalf("unexpected amount of keys in redis: %v", len(keys))
@@ -583,9 +585,14 @@ func TestServe(t *testing.T) {
 				req = req.WithContext(ctx)
 				_, err = http.DefaultClient.Do(req)
 				expErr := "context deadline exceeded"
+				if err == nil {
+					t.Fatal("expected deadline error")
+				}
+
 				if !strings.Contains(err.Error(), "context deadline exceeded") {
 					t.Fatalf("unexpected error: %s; expected: %s", err, expErr)
 				}
+				// verifies if query isn't cached and if kill query was launched.
 				select {
 				case <-fakeCHState.syncCH:
 					// wait while chproxy will detect that request was canceled and will drop temp file
@@ -594,6 +601,43 @@ func TestServe(t *testing.T) {
 				case <-time.After(time.Second * 5):
 					t.Fatalf("expected deadline query to be killed")
 				}
+			},
+			startHTTP,
+		},
+		{
+			"http concurrent transaction fails after grace time",
+			"testdata/http.concurrent.transaction.yml",
+			func(t *testing.T) {
+				// max_exec_time = 300 ms, grace_time = 160 ms (> max_exec_time/2)
+				// scenario: 2 concurrent queries. First one hits clickhouse, second one awaits concurrent query.
+				// First query takes more than grace time to compute, hence the second query fails with timeout status.
+				q := "SELECT SLEEP200"
+				executeTwoConcurrentRequests(t, q, 200, 408, "", "no result found during grace time period")
+			},
+			startHTTP,
+		},
+		{
+			"http concurrent transaction from cache",
+			"testdata/http.concurrent.transaction.yml",
+			func(t *testing.T) {
+
+				// max_exec_time = 300 ms, grace_time = 160 ms (> max_exec_time/2)
+				// scenario: 1st query completes before grace_time elapsed. 2nd query is served from cache.
+
+				q := "SELECT SLEEP100"
+				executeTwoConcurrentRequests(t, q, http.StatusOK, http.StatusOK, "success mate", "success mate")
+			},
+			startHTTP,
+		},
+		{
+			"http concurrent transaction failure scenario",
+			"testdata/http.concurrent.transaction.yml",
+			func(t *testing.T) {
+				// max_exec_time = 300 ms, grace_time = 160 ms (> max_exec_time/2)
+				// scenario: 1st query fails before grace_time elapsed. 2nd query fails as well.
+
+				q := "SELECT ERROR"
+				executeTwoConcurrentRequests(t, q, http.StatusTeapot, http.StatusInternalServerError, "", "concurrent query failed")
 			},
 			startHTTP,
 		},
@@ -645,20 +689,6 @@ func TestServe(t *testing.T) {
 
 			tc.testFn(t)
 		})
-	}
-}
-
-func checkHttpResponse(t *testing.T, resp *http.Response, expectedResp string) {
-	buf := new(bytes.Buffer)
-	_, err := buf.ReadFrom(resp.Body)
-	if err != nil {
-		t.Fatalf("unexpected error while reading a response body: %v", err)
-	}
-	responseBodyStr := buf.String()
-	resp.Body.Close()
-
-	if responseBodyStr != expectedResp {
-		t.Fatalf("got: %q; expected: %q", responseBodyStr, expectedResp)
 	}
 }
 
@@ -734,6 +764,8 @@ func startCHServer() {
 	http.ListenAndServe(":8124", http.HandlerFunc(fakeCHHandler))
 }
 
+var patt = regexp.MustCompile(`(\d+)$`)
+
 func fakeCHHandler(w http.ResponseWriter, r *http.Request) {
 	query, err := getFullQuery(r)
 	if err != nil {
@@ -746,21 +778,40 @@ func fakeCHHandler(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "got empty query for non-GET request")
 		return
 	}
-	switch string(query) {
-	case "SELECT ERROR":
-		w.WriteHeader(http.StatusTeapot)
-		fmt.Fprint(w, "DB::Exception\n")
-	case "SELECT SLEEP":
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "foo")
+	defer func() {
 		if f, ok := w.(http.Flusher); ok {
 			f.Flush()
 		}
-
+	}()
+	q := string(query)
+	switch {
+	case q == "SELECT ERROR":
+		w.WriteHeader(http.StatusTeapot)
+		fmt.Fprint(w, "DB::Exception\n")
+	case q == "SELECT SLEEP":
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "foo")
 		fakeCHState.sleep()
-
 		fmt.Fprint(w, "bar")
-	case "SELECT 1 FORMAT TabSeparatedWithNamesAndTypes":
+
+	case strings.Contains(q, "SELECT SLEEP"):
+		numberStrings := patt.FindAllStringSubmatch(q, -1)
+		if len(numberStrings) == 0 {
+			panic("couldn't extract number from sleep call to clickhouse mock")
+		}
+		nr, err := strconv.Atoi(numberStrings[0][1])
+		if err != nil {
+			panic(err)
+		}
+
+		duration, err := time.ParseDuration(fmt.Sprintf("%vms", nr))
+		if err != nil {
+			panic(err)
+		}
+		time.Sleep(duration)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "success mate") //nolint
+	case q == "SELECT 1 FORMAT TabSeparatedWithNamesAndTypes":
 		w.WriteHeader(http.StatusOK)
 		w.Write(bytesWithInvalidUTFPairs)
 	default:
@@ -769,6 +820,40 @@ func fakeCHHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, "Ok.\n")
+	}
+}
+
+// executeTwoConcurrentRequests concurrently executes 2 requests for the same query.
+// Results are asserted according to the specified input parameters.
+func executeTwoConcurrentRequests(t *testing.T, query string, firstStatusCode, secondStatusCode int, firstBody, secondBody string) {
+	u := fmt.Sprintf("http://127.0.0.1:9090?query=%s&user=concurrent_user", url.QueryEscape(query))
+	req, err := http.NewRequest("GET", u, nil)
+	checkErr(t, err)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	var resp1 string
+	var resp2 string
+	go func() {
+		resp := httpRequest(t, req, firstStatusCode)
+		resp1 = bbToString(t, resp.Body)
+		wg.Done()
+	}()
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		resp := httpRequest(t, req, secondStatusCode)
+		resp2 = bbToString(t, resp.Body)
+		wg.Done()
+	}()
+	wg.Wait()
+
+	if !strings.Contains(resp1, firstBody) {
+		t.Fatalf("concurrent test scenario: unexpected resp body: %s, expected : %s", resp1, firstBody)
+	}
+
+	if !strings.Contains(resp2, secondBody) {
+		t.Fatalf("concurrent test scenario: unexpected resp body: %s, expected : %s", resp2, secondBody)
 	}
 }
 
@@ -782,12 +867,6 @@ type stateCH struct {
 	sync.Mutex
 	inited bool
 	syncCH chan struct{}
-}
-
-func (s *stateCH) isInited() bool {
-	s.Lock()
-	defer s.Unlock()
-	return s.inited
 }
 
 func (s *stateCH) kill() {
@@ -879,6 +958,7 @@ func httpGet(t *testing.T, url string, statusCode int) *http.Response {
 }
 
 func httpRequest(t *testing.T, request *http.Request, statusCode int) *http.Response {
+	t.Helper()
 	client := http.Client{}
 	resp, err := client.Do(request)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -605,18 +605,6 @@ func TestServe(t *testing.T) {
 			startHTTP,
 		},
 		{
-			"http concurrent transaction fails after grace time",
-			"testdata/http.concurrent.transaction.yml",
-			func(t *testing.T) {
-				// max_exec_time = 300 ms, grace_time = 160 ms (> max_exec_time/2)
-				// scenario: 2 concurrent queries. First one hits clickhouse, second one awaits concurrent query.
-				// First query takes more than grace time to compute, hence the second query fails with timeout status.
-				q := "SELECT SLEEP200"
-				executeTwoConcurrentRequests(t, q, 200, 408, "", "no result found during grace time period")
-			},
-			startHTTP,
-		},
-		{
 			"http concurrent transaction from cache",
 			"testdata/http.concurrent.transaction.yml",
 			func(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -357,7 +357,7 @@ func TestServe(t *testing.T) {
 				resp2 := httpRequest(t, req, http.StatusOK)
 				checkResponse(t, resp2.Body, expectedOkResp)
 				keys := redisClient.Keys()
-				if len(keys) != 1 {
+				if len(keys) != 2 { // 2 because there is a record stored for transaction and a cache item
 					t.Fatalf("unexpected amount of keys in redis: %v", len(keys))
 				}
 
@@ -396,7 +396,7 @@ func TestServe(t *testing.T) {
 				// if we do not use base64 to encode/decode the cached payload, EOF error will be thrown here.
 				checkResponse(t, resp2.Body, string(bytesWithInvalidUTFPairs))
 				keys := redisClient.Keys()
-				if len(keys) != 1 {
+				if len(keys) != 2 { // 2 because there is a record stored for transaction, and a cache item
 					t.Fatalf("unexpected amount of keys in redis: %v", len(keys))
 				}
 

--- a/proxy.go
+++ b/proxy.go
@@ -297,13 +297,6 @@ func (rp *reverseProxy) serveFromCache(s *scope, srw *statResponseWriter, req *h
 				respondWith(srw, err, http.StatusInternalServerError)
 				return
 			}
-			// We will assess if elapsed time is bigger than half of the max request timeout.
-			// This precondition halts execution
-			if transaction.ElapsedTime > s.user.maxExecutionTime/2 {
-				err = fmt.Errorf("%s: no result found during grace time period", s)
-				respondWith(srw, err, http.StatusRequestTimeout)
-				return
-			}
 		}
 	}
 

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -251,9 +251,9 @@ func TestReverseProxy_ServeHTTP1(t *testing.T) {
 				p.users["default"].maxConcurrentQueries = 1
 				p.users["default"].queueCh = make(chan struct{}, 1)
 				go makeHeavyRequest(p, time.Millisecond*20)
-				time.Sleep(time.Millisecond * 1) // in case ci runner is slow
+				time.Sleep(time.Millisecond * 5)
 				go makeHeavyRequest(p, time.Millisecond*20)
-				time.Sleep(time.Millisecond * 1)
+				time.Sleep(time.Millisecond * 5)
 				return makeHeavyRequest(p, time.Millisecond*20)
 			},
 		},

--- a/testdata/http.concurrent.transaction.yml
+++ b/testdata/http.concurrent.transaction.yml
@@ -1,0 +1,24 @@
+caches:
+  - name: "concurrent_cache"
+    mode: "file_system"
+    file_system:
+      dir: "temp-test-data/concurrent_cache"
+      max_size: "10M"
+    expire: "1m"
+    grace_time: "160ms"
+
+server:
+  http:
+      listen_addr: ":9090"
+      allowed_networks: ["127.0.0.1/24"]
+
+users:
+  - name: "concurrent_user"
+    cache: "concurrent_cache"
+    to_cluster: "default"
+    to_user: "default"
+    max_execution_time: "300ms"
+
+clusters:
+  - name: "default"
+    nodes: ["127.0.0.1:8124"]


### PR DESCRIPTION
## Description
In this PR I patch a fix for #51 which comes with a slight modification to proposed solution.

### Details
Instead of simply refusing request after `grace_time` period, we refuse if elapsed time achieved half of max execution time of the request.

The rational behind is that:
- the identical query failed to register its completion (TransactionRegistry unavailable)
- configured grace time was too short

### Further improvements
For the case of successful transaction completion:
```
/ There are following options:
// - the identical query failed
// - operation to save the result in cache failed
// To fix that behaviour we can add information in transaction registry. Operation should be expressed as:
// - created
// - failed
// - completed
// and we should store it for the TTL of at most 2 * max_execution_time
```
which I propose to handle in another PR as it's less likely and requires more additional work.