### PR TITLE
Fix redis transaction registry

### DIFF
--- a/cache/transaction_registry_redis.go
+++ b/cache/transaction_registry_redis.go
@@ -37,7 +37,7 @@ func (r *redisTransactionRegistry) Fail(key *Key) error {
 }
 
 func (r *redisTransactionRegistry) updateTransactionState(key *Key, state TransactionState) error {
-	return r.redisClient.Set(context.Background(), toTransactionKey(key), uint64(state), redis.KeepTTL).Err()
+	return r.redisClient.Set(context.Background(), toTransactionKey(key), uint64(state), r.deadline).Err()
 }
 
 func (r *redisTransactionRegistry) Status(key *Key) (TransactionState, error) {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -467,14 +467,14 @@ func TestKillQuery(t *testing.T) {
 			name: "timeout user",
 			f: func(p *reverseProxy) *http.Response {
 				p.users["default"].maxExecutionTime = time.Millisecond * 10
-				return makeHeavyRequest(p, time.Millisecond*20)
+				return makeHeavyRequest(p, time.Millisecond*40)
 			},
 		},
 		{
 			name: "timeout cluster user",
 			f: func(p *reverseProxy) *http.Response {
 				p.clusters["cluster"].users["web"].maxExecutionTime = time.Millisecond * 10
-				return makeHeavyRequest(p, time.Millisecond*20)
+				return makeHeavyRequest(p, time.Millisecond*40)
 			},
 		},
 	}
@@ -492,7 +492,7 @@ func TestKillQuery(t *testing.T) {
 				t.Fatalf("expected Id to be extracted from %q", b)
 			}
 
-			time.Sleep(time.Millisecond * 30)
+			time.Sleep(time.Millisecond * 50)
 			state, err := registry.get(id)
 			if err != nil {
 				t.Fatalf("unexpected requestRegistry err for key %q: %s", id, err)


### PR DESCRIPTION
## Description

Transaction registry methods: Complete and Fail, rely today on KeepTTL argument https://redis.io/commands/set/ available only from redis sever version > 6.x. The idea of this PR is to reduce dependency to specific redis version.

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [x] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Further comments
--- 
