### PR TITLE
doc(max_exec_time): set by default to 30s

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -479,7 +479,7 @@ type User struct {
 	MaxConcurrentQueries uint32 `yaml:"max_concurrent_queries,omitempty"`
 
 	// Maximum duration of query execution for user
-	// if omitted or zero - no limits would be applied
+	// if omitted or zero - limit is set to 30 seconds
 	MaxExecutionTime Duration `yaml:"max_execution_time,omitempty"`
 
 	// Maximum number of requests per minute for user
@@ -720,7 +720,7 @@ type ClusterUser struct {
 	MaxConcurrentQueries uint32 `yaml:"max_concurrent_queries,omitempty"`
 
 	// Maximum duration of query execution for user
-	// if omitted or zero - no limits would be applied
+	// if omitted or zero - limit is set to 30 seconds
 	MaxExecutionTime Duration `yaml:"max_execution_time,omitempty"`
 
 	// Maximum number of requests per minute for user

--- a/config/testdata/full.yml
+++ b/config/testdata/full.yml
@@ -204,7 +204,7 @@ users:
     # The maximum query duration for the user.
     # Timed out queries are forcibly killed via `KILL QUERY`.
     #
-    # By default there is no limit on the query duration.
+    # By default set to 30s.
     max_execution_time: 1m
 
     # Whether to deny input requests over HTTPS.

--- a/docs/content/cn/index.md
+++ b/docs/content/cn/index.md
@@ -549,7 +549,7 @@ users:
     # The maximum query duration for the user.
     # Timed out queries are forcibly killed via `KILL QUERY`.
     #
-    # By default there is no limit on the query duration.
+    # By default set to 30s.
     max_execution_time: 1m
 
     # Whether to deny input requests over HTTPS.

--- a/docs/content/en/configuration/default.md
+++ b/docs/content/en/configuration/default.md
@@ -225,7 +225,7 @@ users:
     # The maximum query duration for the user.
     # Timed out queries are forcibly killed via `KILL QUERY`.
     #
-    # By default there is no limit on the query duration.
+    # By default set to 30s.
     max_execution_time: 1m
 
     # Whether to deny input requests over HTTPS.


### PR DESCRIPTION
## Description
We've introduced a change of behaviour of default max_execution_time of query. Previously it was unlimited. After the [release](https://github.com/ContentSquare/chproxy/releases/tag/v1.15.1) it's limited to 30sec by default. This is the PR to align documentation with current behaviour.

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
#182 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [ ] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
