### PR TITLE
fix(asyncCache): propagation of maxExecutionTime

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -415,7 +415,7 @@ func (rp *reverseProxy) applyConfig(cfg *config.Config) error {
 		}
 		var maxExecutionTime config.Duration
 		for _, user := range cfg.Users {
-			if user.Name == cc.Name {
+			if user.Cache == cc.Name {
 				maxExecutionTime = user.MaxExecutionTime
 				break
 			}


### PR DESCRIPTION
## Description
Fix propagation of **max_execution_time** to async cache.
  
<!--  Please explain the object of this PR and the changes you made.
A reference to a github issue would be appreciated. --> 

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [x] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
