### PR TITLE
fix(proxy): return error message when query fails

### DIFF
--- a/cache/async_cache.go
+++ b/cache/async_cache.go
@@ -94,7 +94,7 @@ func NewAsyncCache(cfg config.Cache, maxExecutionTime time.Duration) (*AsyncCach
 		var redisClient redis.UniversalClient
 		redisClient, err = clients.NewRedisClient(cfg.Redis)
 		cache = newRedisCache(redisClient, cfg)
-		transaction = newRedisTransactionRegistry(redisClient, time.Duration(cfg.GraceTime))
+		transaction = newRedisTransactionRegistry(redisClient, transactionDeadline)
 	default:
 		return nil, fmt.Errorf("unknown config mode")
 	}

--- a/io.go
+++ b/io.go
@@ -52,11 +52,6 @@ func RespondWithData(rw http.ResponseWriter, data io.Reader, metadata cache.Cont
 	return nil
 }
 
-func RespondWithoutData(rw http.ResponseWriter) error {
-	_, err := rw.Write([]byte{})
-	return err
-}
-
 func (rw *statResponseWriter) Write(b []byte) (int, error) {
 	if rw.statusCode == 0 {
 		rw.statusCode = http.StatusOK

--- a/main_test.go
+++ b/main_test.go
@@ -625,7 +625,7 @@ func TestServe(t *testing.T) {
 				// scenario: 1st query fails before grace_time elapsed. 2nd query fails as well.
 
 				q := "SELECT ERROR"
-				executeTwoConcurrentRequests(t, q, http.StatusTeapot, http.StatusInternalServerError, "", "concurrent query failed")
+				executeTwoConcurrentRequests(t, q, http.StatusTeapot, http.StatusInternalServerError, "DB::Exception\n", "concurrent query failed")
 			},
 			startHTTP,
 		},


### PR DESCRIPTION
## Description

In the PR introducing distributed cache we created a regression. It relates to swallowed error message received from Clickhouse.
 
<!--  Please explain the object of this PR and the changes you made.
A reference to a github issue would be appreciated. --> 

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [x] Linter passes correctly
- [x] Add tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
