### PR TITLE
Enhancement: failing concurrent transactions

### DIFF
--- a/cache/filesystem_cache_test.go
+++ b/cache/filesystem_cache_test.go
@@ -83,6 +83,7 @@ func cacheAddGetHelper(t *testing.T, c Cache) {
 		if err != nil {
 			t.Fatalf("failed to get data from filesystem cache: %s", err)
 		}
+		defer cachedData.Data.Close()
 
 		// Verify trw contains valid headers.
 		if cachedData.Type != ct {
@@ -119,6 +120,7 @@ func cacheAddGetHelper(t *testing.T, c Cache) {
 		if err != nil {
 			t.Fatalf("failed to get data from filesystem cache: %s", err)
 		}
+		defer cachedData.Data.Close()
 		value := fmt.Sprintf("value %d", i)
 		//we want to test what happen we the cache handle a big value
 		if i == 0 {
@@ -196,6 +198,7 @@ func TestCacheClean(t *testing.T) {
 		if err != nil {
 			t.Fatalf("create tmp cache: %s", err)
 		}
+		defer crw.Close()
 
 		value := fmt.Sprintf("very big value %d", i)
 		bs := bytes.NewBufferString(value)

--- a/main_test.go
+++ b/main_test.go
@@ -609,7 +609,7 @@ func TestServe(t *testing.T) {
 				// scenario: 1st query fails before grace_time elapsed. 2nd query fails as well.
 
 				q := "SELECT RECOVERABLE-ERROR"
-				executeTwoConcurrentRequests(t, q, http.StatusTeapot, http.StatusTeapot, "DB::Exception\n", "DB::Exception\n")
+				executeTwoConcurrentRequests(t, q, http.StatusServiceUnavailable, http.StatusServiceUnavailable, "DB::Exception\n", "DB::Exception\n")
 			},
 			startHTTP,
 		},
@@ -761,7 +761,7 @@ func fakeCHHandler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprint(w, "DB::Exception\n")
 	case q == "SELECT RECOVERABLE-ERROR":
-		w.WriteHeader(http.StatusTeapot)
+		w.WriteHeader(http.StatusServiceUnavailable)
 		fmt.Fprint(w, "DB::Exception\n")
 	case q == "SELECT SLEEP":
 		w.WriteHeader(http.StatusOK)

--- a/main_test.go
+++ b/main_test.go
@@ -353,9 +353,11 @@ func TestServe(t *testing.T) {
 					t.Fatalf("unexpected amount of keys in redis: %v", len(keys))
 				}
 
-				resp := httpRequest(t, req, http.StatusOK)
+				resp, err := httpRequest(t, req, http.StatusOK)
+				checkErr(t, err)
 				checkResponse(t, resp.Body, expectedOkResp)
-				resp2 := httpRequest(t, req, http.StatusOK)
+				resp2, err := httpRequest(t, req, http.StatusOK)
+				checkErr(t, err)
 				checkResponse(t, resp2.Body, expectedOkResp)
 				keys = redisClient.Keys()
 				if len(keys) != 2 { // expected 2 because there is a record stored for transaction and a cache item
@@ -391,9 +393,11 @@ func TestServe(t *testing.T) {
 				req, err := http.NewRequest("GET", "http://127.0.0.1:9090?query="+url.QueryEscape(q), nil)
 				checkErr(t, err)
 
-				resp := httpRequest(t, req, http.StatusOK)
+				resp, err := httpRequest(t, req, http.StatusOK)
+				checkErr(t, err)
 				checkResponse(t, resp.Body, string(bytesWithInvalidUTFPairs))
-				resp2 := httpRequest(t, req, http.StatusOK)
+				resp2, err := httpRequest(t, req, http.StatusOK)
+				checkErr(t, err)
 				// if we do not use base64 to encode/decode the cached payload, EOF error will be thrown here.
 				checkResponse(t, resp2.Body, string(bytesWithInvalidUTFPairs))
 				keys = redisClient.Keys()
@@ -609,7 +613,7 @@ func TestServe(t *testing.T) {
 				// scenario: 1st query fails before grace_time elapsed. 2nd query fails as well.
 
 				q := "SELECT RECOVERABLE-ERROR"
-				executeTwoConcurrentRequests(t, q, http.StatusServiceUnavailable, http.StatusServiceUnavailable, "DB::Exception\n", "DB::Exception\n")
+				executeTwoConcurrentRequests(t, q, http.StatusServiceUnavailable, http.StatusServiceUnavailable, "DB::Unavailable\n", "DB::Unavailable\n")
 			},
 			startHTTP,
 		},
@@ -761,8 +765,9 @@ func fakeCHHandler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprint(w, "DB::Exception\n")
 	case q == "SELECT RECOVERABLE-ERROR":
+		println("called clickhouse recoverable")
 		w.WriteHeader(http.StatusServiceUnavailable)
-		fmt.Fprint(w, "DB::Exception\n")
+		fmt.Fprint(w, "DB::Unavailable\n")
 	case q == "SELECT SLEEP":
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, "foo")
@@ -802,26 +807,48 @@ func fakeCHHandler(w http.ResponseWriter, r *http.Request) {
 // Results are asserted according to the specified input parameters.
 func executeTwoConcurrentRequests(t *testing.T, query string, firstStatusCode, secondStatusCode int, firstBody, secondBody string) {
 	u := fmt.Sprintf("http://127.0.0.1:9090?query=%s&user=concurrent_user", url.QueryEscape(query))
-	req, err := http.NewRequest("GET", u, nil)
-	checkErr(t, err)
 
 	var wg sync.WaitGroup
 	wg.Add(2)
 	var resp1 string
 	var resp2 string
+	errs := make(chan error, 0)
+	defer close(errs)
+	errors := make([]error, 0)
 	go func() {
-		resp := httpRequest(t, req, firstStatusCode)
+		for err := range errs {
+			errors = append(errors, err)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		req, err := http.NewRequest("GET", u, nil)
+		checkErr(t, err)
+		resp, err := httpRequest(t, req, firstStatusCode)
+		if err != nil {
+			errs <- err
+			return
+		}
 		resp1 = bbToString(t, resp.Body)
-		wg.Done()
 	}()
 
 	go func() {
+		defer wg.Done()
 		time.Sleep(20 * time.Millisecond)
-		resp := httpRequest(t, req, secondStatusCode)
+		req, err := http.NewRequest("GET", u, nil)
+		checkErr(t, err)
+		resp, err := httpRequest(t, req, secondStatusCode)
+		if err != nil {
+			errs <- err
+			return
+		}
 		resp2 = bbToString(t, resp.Body)
-		wg.Done()
 	}()
 	wg.Wait()
+
+	if len(errors) != 0 {
+		t.Fatalf("concurrent test scenario failed due to: %v", errors)
+	}
 
 	if !strings.Contains(resp1, firstBody) {
 		t.Fatalf("concurrent test scenario: unexpected resp body: %s, expected : %s", resp1, firstBody)
@@ -932,15 +959,15 @@ func httpGet(t *testing.T, url string, statusCode int) *http.Response {
 	return resp
 }
 
-func httpRequest(t *testing.T, request *http.Request, statusCode int) *http.Response {
+func httpRequest(t *testing.T, request *http.Request, statusCode int) (*http.Response, error) {
 	t.Helper()
 	client := http.Client{}
 	resp, err := client.Do(request)
 	if err != nil {
-		t.Fatalf("unexpected erorr while doing GET request: %s", err)
+		return resp, fmt.Errorf("unexpected erorr while doing GET request: %s", err)
 	}
 	if resp.StatusCode != statusCode {
-		t.Fatalf("unexpected status code: %d; expected: %d", resp.StatusCode, statusCode)
+		return resp, fmt.Errorf("unexpected status code: %d; expected: %d", resp.StatusCode, statusCode)
 	}
-	return resp
+	return resp, nil
 }

--- a/proxy.go
+++ b/proxy.go
@@ -349,13 +349,6 @@ func (rp *reverseProxy) serveFromCache(s *scope, srw *statResponseWriter, req *h
 		}
 		rp.completeTransaction(s, statusCode, userCache, key, q)
 
-		// mark transaction as failed
-		// todo: discuss if we should mark it as failed upon timeout. The rational against it would be to hope that
-		// 		 partial results of the query are cached and therefore subsequent execution can succeed
-		if err = userCache.Fail(key); err != nil {
-			log.Errorf("%s: %s; query: %q", s, err, q)
-		}
-
 		err = RespondWithData(srw, reader, contentMetadata, 0*time.Second, statusCode)
 		if err != nil {
 			err = fmt.Errorf("%s: %w; query: %q", s, err, q)

--- a/proxy.go
+++ b/proxy.go
@@ -279,7 +279,6 @@ func (rp *reverseProxy) serveFromCache(s *scope, srw *statResponseWriter, req *h
 		_ = RespondWithData(srw, cachedData.Data, cachedData.ContentMetadata, cachedData.Ttl, http.StatusOK)
 		return
 	}
-
 	// Await for potential result from concurrent query
 	transactionState, err := userCache.AwaitForConcurrentTransaction(key)
 	if err != nil {
@@ -288,8 +287,8 @@ func (rp *reverseProxy) serveFromCache(s *scope, srw *statResponseWriter, req *h
 	} else {
 		if transactionState.IsCompleted() {
 			cachedData, err := userCache.Get(key)
-			defer cachedData.Data.Close()
 			if err == nil {
+				defer cachedData.Data.Close()
 				_ = RespondWithData(srw, cachedData.Data, cachedData.ContentMetadata, cachedData.Ttl, http.StatusOK)
 				cacheHitFromConcurrentQueries.With(labels).Inc()
 				log.Debugf("%s: cache hit after awaiting concurrent query", s)
@@ -348,7 +347,6 @@ func (rp *reverseProxy) serveFromCache(s *scope, srw *statResponseWriter, req *h
 			tmpFileRespWriter.WriteHeader(srw.statusCode)
 		}
 		rp.completeTransaction(s, statusCode, userCache, key, q)
-
 		err = RespondWithData(srw, reader, contentMetadata, 0*time.Second, statusCode)
 		if err != nil {
 			err = fmt.Errorf("%s: %w; query: %q", s, err, q)

--- a/proxy.go
+++ b/proxy.go
@@ -381,7 +381,8 @@ func (rp *reverseProxy) serveFromCache(s *scope, srw *statResponseWriter, req *h
 
 // clickhouseRecoverableStatusCodes set of recoverable http responses' status codes from Clickhouse.
 // When such happens we mark transaction as completed and let concurrent query to hit another Clickhouse shard.
-var clickhouseRecoverableStatusCodes = map[int]struct{}{503: {}}
+// possible http error codes in clickhouse (i.e: https://github.com/ClickHouse/ClickHouse/blob/master/src/Server/HTTPHandler.cpp)
+var clickhouseRecoverableStatusCodes = map[int]struct{}{http.StatusServiceUnavailable: {}}
 
 func (rp *reverseProxy) completeTransaction(s *scope, statusCode int, userCache *cache.AsyncCache, key *cache.Key, q []byte) {
 	if statusCode < 300 {


### PR DESCRIPTION
## Description
Mark transaction registry record as failed, upon query failure, only for non-recoverable status codes.

Created to trigger discussion.
<!--  Please explain the object of this PR and the changes you made.
A reference to a github issue would be appreciated. --> 

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Enhancement 


### Checklist

- [x] Linter passes correctly
- [x] Add tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
