### PR TITLE
set default max_execution_time to 120s

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,7 @@ var (
 		Response: "1\n",
 	}
 
-	defaultExecutionTime = Duration(30 * time.Second)
+	defaultExecutionTime = Duration(120 * time.Second)
 )
 
 // Config describes server configuration, access and proxy rules
@@ -479,7 +479,7 @@ type User struct {
 	MaxConcurrentQueries uint32 `yaml:"max_concurrent_queries,omitempty"`
 
 	// Maximum duration of query execution for user
-	// if omitted or zero - limit is set to 30 seconds
+	// if omitted or zero - limit is set to 120 seconds
 	MaxExecutionTime Duration `yaml:"max_execution_time,omitempty"`
 
 	// Maximum number of requests per minute for user
@@ -720,7 +720,7 @@ type ClusterUser struct {
 	MaxConcurrentQueries uint32 `yaml:"max_concurrent_queries,omitempty"`
 
 	// Maximum duration of query execution for user
-	// if omitted or zero - limit is set to 30 seconds
+	// if omitted or zero - limit is set to 120 seconds
 	MaxExecutionTime Duration `yaml:"max_execution_time,omitempty"`
 
 	// Maximum number of requests per minute for user

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -54,7 +54,7 @@ var fullConfig = Config{
 			},
 			TimeoutCfg: TimeoutCfg{
 				ReadTimeout:  Duration(time.Minute),
-				WriteTimeout: Duration(140 * time.Second),
+				WriteTimeout: Duration(215 * time.Second),
 				IdleTimeout:  Duration(10 * time.Minute),
 			},
 		},
@@ -187,7 +187,7 @@ var fullConfig = Config{
 			ReqPerMin:        4,
 			MaxQueueSize:     100,
 			MaxQueueTime:     Duration(35 * time.Second),
-			MaxExecutionTime: Duration(30 * time.Second),
+			MaxExecutionTime: Duration(2 * time.Minute),
 			Cache:            "longterm",
 			Params:           "web",
 		},
@@ -250,7 +250,7 @@ func TestLoadConfig(t *testing.T) {
 						NetworksOrGroups: []string{"127.0.0.1"},
 						TimeoutCfg: TimeoutCfg{
 							ReadTimeout:  Duration(time.Minute),
-							WriteTimeout: Duration(90 * time.Second),
+							WriteTimeout: Duration(3 * time.Minute),
 							IdleTimeout:  Duration(10 * time.Minute),
 						},
 					},
@@ -278,7 +278,7 @@ func TestLoadConfig(t *testing.T) {
 						Name:             "default",
 						ToCluster:        "cluster",
 						ToUser:           "default",
-						MaxExecutionTime: Duration(30 * time.Second),
+						MaxExecutionTime: Duration(120 * time.Second),
 					},
 				},
 			},
@@ -608,7 +608,7 @@ func TestConfigTimeouts(t *testing.T) {
 			"testdata/default_values.yml",
 			TimeoutCfg{
 				ReadTimeout:  Duration(time.Minute),
-				WriteTimeout: Duration(90 * time.Second), // defaultExecutionTime + 1 min
+				WriteTimeout: Duration(3 * time.Minute), // defaultExecutionTime + 1 min
 				IdleTimeout:  Duration(10 * time.Minute),
 			},
 		},
@@ -715,7 +715,7 @@ func TestConfigString(t *testing.T) {
       allowed_hosts:
       - example.com
     read_timeout: 1m
-    write_timeout: 140s
+    write_timeout: 215s
     idle_timeout: 10m
   metrics:
     allowed_networks:
@@ -791,7 +791,7 @@ users:
   password: XXX
   to_cluster: first cluster
   to_user: web
-  max_execution_time: 30s
+  max_execution_time: 2m
   requests_per_minute: 4
   max_queue_size: 100
   max_queue_time: 35s

--- a/config/testdata/full.yml
+++ b/config/testdata/full.yml
@@ -204,7 +204,7 @@ users:
     # The maximum query duration for the user.
     # Timed out queries are forcibly killed via `KILL QUERY`.
     #
-    # By default set to 30s.
+    # By default set to 120s.
     max_execution_time: 1m
 
     # Whether to deny input requests over HTTPS.

--- a/docs/content/cn/index.md
+++ b/docs/content/cn/index.md
@@ -549,7 +549,7 @@ users:
     # The maximum query duration for the user.
     # Timed out queries are forcibly killed via `KILL QUERY`.
     #
-    # By default set to 30s.
+    # By default set to 120s.
     max_execution_time: 1m
 
     # Whether to deny input requests over HTTPS.

--- a/docs/content/en/configuration/default.md
+++ b/docs/content/en/configuration/default.md
@@ -225,7 +225,7 @@ users:
     # The maximum query duration for the user.
     # Timed out queries are forcibly killed via `KILL QUERY`.
     #
-    # By default set to 30s.
+    # By default set to 120s.
     max_execution_time: 1m
 
     # Whether to deny input requests over HTTPS.


### PR DESCRIPTION
## Description

<!--  Please explain the object of this PR and the changes you made.
A reference to a github issue would be appreciated. --> 
Cf the following issue https://github.com/ContentSquare/chproxy/issues/182, a bug was introduced in chproxy a few months ago and the default value of max_execution_time went to unlimited to 30 sec. Its complex to make it unlimited again so the tradeoff is to increase the default value so that is doesn't impact some users

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [ ] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No
user upgrading to this version who didn't set the max_execution_time will get a default value of 120 sec (instead of 30 sec in the previous releases).
## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
