### PR TITLE
refactor: use os and io packages to replace some ioutils functions

### DIFF
--- a/cache/filesystem_cache.go
+++ b/cache/filesystem_cache.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -118,7 +117,7 @@ func (f *fileSystemCache) Get(key *Key) (*CachedData, error) {
 		// with the fresh file during deadline.
 	}
 
-	b, err := ioutil.ReadAll(file)
+	b, err := io.ReadAll(file)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file content from %q: %w", f.Name(), err)

--- a/chdecompressor/decompressor_test.go
+++ b/chdecompressor/decompressor_test.go
@@ -2,7 +2,7 @@ package chdecompressor
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 )
 
@@ -43,7 +43,7 @@ func TestRead(t *testing.T) {
 func testDecompress(t *testing.T, str, expected string) {
 	bb := bytes.NewBufferString(str)
 	r := NewReader(bb)
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatalf("cannot decompress %q: %s", expected, err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/mohae/deepcopy"
@@ -767,7 +767,7 @@ func (cu *ClusterUser) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // LoadFile loads and validates configuration from provided .yml file
 func LoadFile(filename string) (*Config, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -53,7 +53,7 @@ func (hb *heartBeat) isHealthy(addr string) error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("non-200 status code: %s", resp.Status)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("cannot read response in %s: %w", time.Since(startTime), err)
 	}

--- a/io_test.go
+++ b/io_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http/httptest"
 	"testing"
 )
@@ -10,10 +10,10 @@ import (
 func TestCachedReadCloser(t *testing.T) {
 	b := makeQuery(1000)
 	crc := &cachedReadCloser{
-		ReadCloser: ioutil.NopCloser(bytes.NewReader(b)),
+		ReadCloser: io.NopCloser(bytes.NewReader(b)),
 	}
 	req := httptest.NewRequest("POST", "http://localhost", crc)
-	res, err := ioutil.ReadAll(req.Body)
+	res, err := io.ReadAll(req.Body)
 	if err != nil {
 		t.Fatalf("cannot obtain response: %s", err)
 	}

--- a/log/log.go
+++ b/log/log.go
@@ -2,7 +2,7 @@ package log
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"sync/atomic"
@@ -18,16 +18,16 @@ var (
 	fatalLogger = log.New(os.Stderr, "FATAL: ", stdLogFlags)
 
 	// NilLogger suppresses all the log messages.
-	NilLogger = log.New(ioutil.Discard, "", stdLogFlags)
+	NilLogger = log.New(io.Discard, "", stdLogFlags)
 )
 
 // SuppressOutput suppresses all output from logs if `suppress` is true
 // used while testing
 func SuppressOutput(suppress bool) {
 	if suppress {
-		debugLogger.SetOutput(ioutil.Discard)
-		infoLogger.SetOutput(ioutil.Discard)
-		errorLogger.SetOutput(ioutil.Discard)
+		debugLogger.SetOutput(io.Discard)
+		infoLogger.SetOutput(io.Discard)
+		errorLogger.SetOutput(io.Discard)
 	} else {
 		debugLogger.SetOutput(os.Stderr)
 		infoLogger.SetOutput(os.Stderr)

--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -22,9 +21,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/contentsquare/chproxy/cache"
-
 	"github.com/alicebob/miniredis/v2"
+	"github.com/contentsquare/chproxy/cache"
 	"github.com/contentsquare/chproxy/config"
 	"github.com/contentsquare/chproxy/log"
 )
@@ -446,7 +444,7 @@ func TestServe(t *testing.T) {
 				req.Header.Set("Content-Encoding", "gzip")
 				resp, err := http.DefaultClient.Do(req)
 				checkErr(t, err)
-				body, _ := ioutil.ReadAll(resp.Body)
+				body, _ := io.ReadAll(resp.Body)
 				if resp.StatusCode != http.StatusOK {
 					t.Fatalf("unexpected status code: %d; expected: %d; body: %s", resp.StatusCode, http.StatusOK, string(body))
 				}
@@ -681,7 +679,7 @@ func TestServe(t *testing.T) {
 }
 
 func checkFilesCount(t *testing.T, dir string, expectedLen int) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatalf("error while reading dir %q: %s", dir, err)
 	}
@@ -924,7 +922,7 @@ func checkResponse(t *testing.T, r io.Reader, expected string) {
 	if r == nil {
 		t.Fatal("unexpected nil reader")
 	}
-	response, err := ioutil.ReadAll(r)
+	response, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatalf("unexpected err while reading: %s", err)
 	}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"regexp"
@@ -644,7 +643,7 @@ var (
 			return
 		}
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			panic(err)
 		}
@@ -731,7 +730,7 @@ func newConfig() *config.Config {
 }
 
 func bbToString(t *testing.T, r io.Reader) string {
-	response, err := ioutil.ReadAll(r)
+	response, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatalf("unexpected err while reading: %s", err)
 	}

--- a/scope.go
+++ b/scope.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -283,12 +283,12 @@ func (s *scope) killQuery() error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		responseBody, _ := ioutil.ReadAll(resp.Body)
+		responseBody, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("unexpected status code returned from query %q at %q: %d. Response body: %q",
 			query, addr, resp.StatusCode, responseBody)
 	}
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("cannot read response body for the query %q: %w", query, err)
 	}

--- a/utils.go
+++ b/utils.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sort"
 	"strconv"
@@ -97,7 +96,7 @@ func getQuerySnippetFromBody(req *http.Request) string {
 	// 'read' request body, so it traps into to crc.
 	// Ignore any errors, since getQuerySnippet is called only
 	// during error reporting.
-	io.Copy(ioutil.Discard, crc) // nolint
+	io.Copy(io.Discard, crc) // nolint
 	data := crc.String()
 
 	u := getDecompressor(req)
@@ -146,12 +145,12 @@ func getFullQueryFromBody(req *http.Request) ([]byte, error) {
 		return nil, nil
 	}
 
-	data, err := ioutil.ReadAll(req.Body)
+	data, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, err
 	}
 	// restore body for further reading
-	req.Body = ioutil.NopCloser(bytes.NewBuffer(data))
+	req.Body = io.NopCloser(bytes.NewBuffer(data))
 	u := getDecompressor(req)
 	if u == nil {
 		return data, nil
@@ -259,14 +258,14 @@ func (dc gzipDecompressor) decompress(r io.Reader) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot ungzip query: %w", err)
 	}
-	return ioutil.ReadAll(gr)
+	return io.ReadAll(gr)
 }
 
 type chDecompressor struct{}
 
 func (dc chDecompressor) decompress(r io.Reader) ([]byte, error) {
 	lr := chdecompressor.NewReader(r)
-	return ioutil.ReadAll(lr)
+	return io.ReadAll(lr)
 }
 
 func calcMapHash(m map[string]string) (uint32, error) {


### PR DESCRIPTION
## Description

<!--  Please explain the object of this PR and the changes you made.
A reference to a github issue would be appreciated. --> 
Some functions in ioutils package are provided in os and io packages after go1.16. Use io or os package directly.
## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [x] Linter passes correctly
- [x] Add tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
