### PR TITLE
refactor: use io.ReadCloser instead of io.Reader in CacheData

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -24,7 +24,7 @@ type ContentMetadata struct {
 
 type CachedData struct {
 	ContentMetadata
-	Data io.Reader
+	Data io.ReadCloser
 	Ttl  time.Duration
 }
 

--- a/cache/redis_cache.go
+++ b/cache/redis_cache.go
@@ -132,7 +132,7 @@ func (r *redisCache) Get(key *Key) (*CachedData, error) {
 			Type:     payload.Type,
 			Encoding: payload.Encoding,
 		},
-		Data: bytes.NewReader(decoded),
+		Data: io.NopCloser(bytes.NewReader(decoded)),
 		Ttl:  ttl,
 	}
 

--- a/proxy.go
+++ b/proxy.go
@@ -268,6 +268,12 @@ func (rp *reverseProxy) serveFromCache(s *scope, srw *statResponseWriter, req *h
 	userCache := s.user.cache
 	// Try to serve from cache
 	cachedData, err := userCache.Get(key)
+	defer func() {
+		if cachedData != nil && cachedData.Data != nil {
+			cachedData.Data.Close()
+		}
+	}()
+
 	if err == nil {
 		// The response has been successfully served from cache.
 		cacheHit.With(labels).Inc()


### PR DESCRIPTION
## Description

<!--  Please explain the object of this PR and the changes you made.
A reference to a github issue would be appreciated. --> 
**Current problem:** 
When reading cache in file system mode, it will use io.ReadAll to read all cache payload to process memory. When cache is big, it will make OOM problem.

**Optimization:**
1. Put file as io.Reader to CacheData directly instead of io.ReadAll  bytes
2. Change io.Reader to io.ReadCloser and close io stream when send finished.

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [x] Linter passes correctly
- [x] Add tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
