### PR TITLE
Wildcarded users

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -4,7 +4,7 @@
  - `<addr>`: string value consisting of a hostname or IP followed by an optional port number
  - `<scheme>`: a string that can take the values `http` or `https`
  - `<duration>`: a duration matching the regular expression `^([0-9]+)(w|d|h|m|s|ms|µs|ns)`
- - `<networks>`: string value consisting of IP, IP mask or named group, for example `"127.0.0.1"` or `"127.0.0.1/24"`. 
+ - `<networks>`: string value consisting of IP, IP mask or named group, for example `"127.0.0.1"` or `"127.0.0.1/24"`.
  - `<host_name>`: string value consisting of host name, for example `"example.com"`
  - `<byte_size>`: string value matching the regular expression `/^\d+(\.\d+)?[KMGTP]?B?$/i`, for example `"100MB"`
 
@@ -68,8 +68,8 @@ file_system:
 # Expiration time for cached responses.
 expire: <duration>
 
-# DEPRECATED: default value equal to `max_execution_time` should be used. 
-#             New configuration parameter will be provided to disable the protection at will. 
+# DEPRECATED: default value equal to `max_execution_time` should be used.
+#             New configuration parameter will be provided to disable the protection at will.
 # When multiple requests with identical query simultaneously hit `chproxy`
 # and there is no cached response for the query, then only a single
 # request will be proxied to clickhouse. Other requests will wait
@@ -80,7 +80,7 @@ expire: <duration>
 # from `thundering herd` problem.
 grace_time: <duration>
 
-# Maximum total size of request payload for caching. The default value 
+# Maximum total size of request payload for caching. The default value
 # is set to 1 Petabyte.
 max_payload_size: <byte_size>
 ```
@@ -96,7 +96,7 @@ mode: "redis"
 
 # Applicable for cache mode: redis
 redis:
-  # list of addresses to redis nodes 
+  # list of addresses to redis nodes
   # you should use multiple addresses only if they all belong to the same redis cluster.
   addresses:
     - <string> # example "localhost:6379"
@@ -106,8 +106,8 @@ redis:
 # Expiration time for cached responses.
 expire: <duration>
 
-# DEPRECATED: default value equal to `max_execution_time` should be used. 
-#             New configuration parameter will be provided to disable the protection at will. 
+# DEPRECATED: default value equal to `max_execution_time` should be used.
+#             New configuration parameter will be provided to disable the protection at will.
 # When multiple requests with identical query simultaneously hit `chproxy`
 # and there is no cached response for the query, then only a single
 # request will be proxied to clickhouse. Other requests will wait
@@ -272,6 +272,12 @@ cache: <string> | optional
 # Optional group of params name to send to ClickHouse with each proxied request from <param_groups_config>
 # By default no additional params are sent to ClickHouse.
 params: <string> | optional
+
+# The user is wildcarded
+# Name matches prefix_*
+# Name and password to ClickHouse are obtained
+# from original request, not from cluster user
+is_wildcarded: <bool> | optional | default = false
 ```
 
 ### <cluster_config>
@@ -322,7 +328,7 @@ nodes: <addr> ...
 name: <string>
 
 # User password in ClickHouse `users.xml` config
-password: <string> | optional 
+password: <string> | optional
 
 # Maximum number of concurrently running queries for user
 # By default there is no limit on the number of concurrently
@@ -368,4 +374,10 @@ request: <string> | optional | default = `/?query=SELECT%201`
 
 # Reference response from clickhouse on health check request
 response: <string> | optional | default = `1\n`
+
+# Credentials to send heartbeat requests
+# for anything except '/ping'.
+# If not specified, the first cluster user' creadentials are used
+user: <string> | optional
+password: <string> | optional
 ```

--- a/config/config.go
+++ b/config/config.go
@@ -447,9 +447,6 @@ type HeartBeat struct {
 	User     string `yaml:"user,omitempty"`
 	Password string `yaml:"password,omitempty"`
 
-	// True if not '/ping'
-	UserNeeded bool
-
 	// Catches all undefined fields
 	XXX map[string]interface{} `yaml:",inline"`
 }
@@ -460,10 +457,6 @@ func (h *HeartBeat) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := unmarshal((*plain)(h)); err != nil {
 		return err
 	}
-	if h.Request != "/ping" {
-		h.UserNeeded = true
-	}
-
 	return checkOverflow(h.XXX, "heartbeat")
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -59,13 +59,13 @@ type Config struct {
 
 	ParamGroups []ParamGroup `yaml:"param_groups,omitempty"`
 
-	// Catches all undefined fields
-	XXX map[string]interface{} `yaml:",inline"`
-
 	networkReg map[string]Networks
 
 	// A wildcared user is found in config
-	HasWildcarded bool `yaml:"has_wildcarded,omitempty"`
+	HasWildcarded bool
+
+	// Catches all undefined fields
+	XXX map[string]interface{} `yaml:",inline"`
 }
 
 // String implements the Stringer interface

--- a/config/config.go
+++ b/config/config.go
@@ -65,7 +65,7 @@ type Config struct {
 	networkReg map[string]Networks
 
 	// A wildcared user is found in config
-	HasWildcarded bool
+	HasWildcarded bool `yaml:"has_wildcarded,omitempty"`
 }
 
 // String implements the Stringer interface

--- a/config/config.go
+++ b/config/config.go
@@ -61,9 +61,6 @@ type Config struct {
 
 	networkReg map[string]Networks
 
-	// A wildcared user is found in config
-	HasWildcarded bool
-
 	// Catches all undefined fields
 	XXX map[string]interface{} `yaml:",inline"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/mohae/deepcopy"
@@ -29,6 +30,8 @@ var (
 		Timeout:  Duration(time.Second * 3),
 		Request:  "/ping",
 		Response: "Ok.\n",
+		Name:     "",
+		Password: "",
 	}
 
 	defaultExecutionTime = Duration(120 * time.Second)
@@ -365,6 +368,10 @@ func (c *Cluster) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return fmt.Errorf("`cluster.heartbeat` cannot be unset for %q", c.Name)
 	}
 
+	if strings.HasSuffix(c.ClusterUsers[0].Name, "_*") && len(c.HeartBeat.Name) == 0 {
+		return fmt.Errorf("`cluster.heartbeat.user ` cannot be unset for %q because a wildcarded user cannot send heartbeat", c.Name)
+	}
+
 	return checkOverflow(c.XXX, fmt.Sprintf("cluster %q", c.Name))
 }
 
@@ -437,6 +444,10 @@ type HeartBeat struct {
 	// Reference response from clickhouse on health check request
 	// default value is `Ok.\n`
 	Response string `yaml:"response,omitempty"`
+
+	Name string `yaml:"name,omitempty"`
+
+	Password string `yaml:"password,omitempty"`
 
 	// Catches all undefined fields
 	XXX map[string]interface{} `yaml:",inline"`

--- a/config/config.go
+++ b/config/config.go
@@ -768,9 +768,6 @@ type ClusterUser struct {
 	// if omitted or zero - no limits would be applied
 	AllowedNetworks Networks `yaml:"-"`
 
-	// A wildcarded user is mapped to this cluster user
-	// IsWildcarded bool
-
 	// Catches all undefined fields
 	XXX map[string]interface{} `yaml:",inline"`
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -858,7 +858,6 @@ param_groups:
     value: "30"
   - key: max_execution_time
     value: "30"
-haswildcarded: false
 `
 	tested := fullConfig.String()
 	if tested != expected {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -140,6 +140,8 @@ var fullConfig = Config{
 				Timeout:  Duration(10 * time.Second),
 				Request:  "/ping",
 				Response: "Ok.\n",
+				Name:     "hbuser",
+				Password: "hbpassword",
 			},
 		},
 	},
@@ -447,6 +449,11 @@ func TestBadConfig(t *testing.T) {
 			"max payload size to cache",
 			"testdata/bad.max_payload_size.yml",
 			"cannot parse byte size \"-10B\": it must be positive float followed by optional units. For example, 1.5Gb, 3T",
+		},
+		{
+			"no heartbeat user if first cluster user is wildcarded",
+			"testdata/bad.wildcarded_users.no.config.yml",
+			"`cluster.heartbeat.user ` cannot be unset for \"default\" because a wildcarded user cannot send heartbeat",
 		},
 	}
 
@@ -781,6 +788,8 @@ clusters:
     request: /ping
     response: |
       Ok.
+    name: hbuser
+    password: hbpassword
 users:
 - name: web
   password: XXX

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -452,9 +452,9 @@ func TestBadConfig(t *testing.T) {
 			"cannot parse byte size \"-10B\": it must be positive float followed by optional units. For example, 1.5Gb, 3T",
 		},
 		{
-			"no heartbeat user, first cluster user is wildcarded, request is not /ping",
-			"testdata/bad.wildcarded_users.no.config.yml",
-			"`cluster.heartbeat.user ` cannot be unset for \"default\" because a wildcarded user cannot send heartbeat",
+			"user is marked as is_wildcarded, but it's name is not consist of a prefix, underscore and asterisk",
+			"testdata/bad.wildcarded_users.no.wildcard.yml",
+			"user name \"analyst_named\" marked 'is_wildcared' does not match 'prefix_*'",
 		},
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -138,11 +138,10 @@ var fullConfig = Config{
 				},
 			},
 			HeartBeat: HeartBeat{
-				Interval:   Duration(2 * time.Minute),
-				Timeout:    Duration(10 * time.Second),
-				Request:    "/?query=SELECT%201",
-				Response:   "Ok.\n",
-				UserNeeded: true,
+				Interval: Duration(2 * time.Minute),
+				Timeout:  Duration(10 * time.Second),
+				Request:  "/?query=SELECT%201",
+				Response: "Ok.\n",
 			},
 		},
 	},
@@ -744,7 +743,6 @@ clusters:
     request: /ping
     response: |
       Ok.
-    userneeded: false
 - name: second cluster
   scheme: https
   replicas:
@@ -778,7 +776,6 @@ clusters:
       Ok.
     user: hbuser
     password: hbpassword
-    userneeded: false
 - name: third cluster
   scheme: http
   nodes:
@@ -793,7 +790,6 @@ clusters:
     request: /?query=SELECT%201
     response: |
       Ok.
-    userneeded: true
 users:
 - name: web
   password: XXX

--- a/config/examples/wildcarded.yml
+++ b/config/examples/wildcarded.yml
@@ -1,0 +1,29 @@
+log_debug: true
+
+server:
+  http:
+      listen_addr: ":9090"
+      allowed_networks: ["127.0.0.0/24"]
+users:
+  # wildcarded user
+  # matches with any name with prefix 'analyst_'
+  # e.g. 'analyst_joe' or 'analyst_jane'
+  - name: "analyst_*"
+    to_cluster: "default"
+    to_user: "analyst_*"
+  # normal user
+  - name: "dba"
+    password: "dba_ingress_pass"
+    to_cluster: "default"
+    to_user: "dba"
+clusters:
+  - name: "default"
+    nodes: ["127.0.0.1:8123"]
+
+    users:
+    - name: "analyst_*"
+    - name: "dba"
+      password: "dba_egress_pass"
+    heartbeat:
+      name: "hbuser"
+      request: "/?query=SELECT%201"

--- a/config/examples/wildcarded.yml
+++ b/config/examples/wildcarded.yml
@@ -8,9 +8,11 @@ users:
   # wildcarded user
   # matches with any name with prefix 'analyst_'
   # e.g. 'analyst_joe' or 'analyst_jane'
+  # ClickHouse password obtained from original message, not from cluster user configuration
   - name: "analyst_*"
     to_cluster: "default"
     to_user: "analyst_*"
+    is_wildcarded: Yes
   # normal user
   - name: "dba"
     password: "dba_ingress_pass"
@@ -19,7 +21,6 @@ users:
 clusters:
   - name: "default"
     nodes: ["127.0.0.1:8123"]
-
     users:
     - name: "analyst_*"
     - name: "dba"

--- a/config/testdata/bad.wildcarded_users.no.config.yml
+++ b/config/testdata/bad.wildcarded_users.no.config.yml
@@ -1,0 +1,26 @@
+log_debug: true
+
+server:
+  http:
+      listen_addr: ":9090"
+      allowed_networks: ["127.0.0.0/24"]
+users:
+  # wildcarded user
+  # matches with any name with prefix 'analyst_'
+  # e.g. 'analyst_joe' or 'analyst_jane'
+  - name: "analyst_*"
+    to_cluster: "default"
+    to_user: "analyst_*"
+  # normal user
+  - name: "dba"
+    password: "dba_ingress_pass"
+    to_cluster: "default"
+    to_user: "dba"
+clusters:
+  - name: "default"
+    nodes: ["127.0.0.1:8123"]
+
+    users:
+    - name: "analyst_*"
+    - name: "dba"
+      password: "dba_egress_pass"

--- a/config/testdata/bad.wildcarded_users.no.config.yml
+++ b/config/testdata/bad.wildcarded_users.no.config.yml
@@ -24,3 +24,5 @@ clusters:
     - name: "analyst_*"
     - name: "dba"
       password: "dba_egress_pass"
+    heartbeat:
+      request:  "/?query=SELECT%201"

--- a/config/testdata/bad.wildcarded_users.no.wildcard.yml
+++ b/config/testdata/bad.wildcarded_users.no.wildcard.yml
@@ -8,7 +8,8 @@ users:
   # wildcarded user
   # matches with any name with prefix 'analyst_'
   # e.g. 'analyst_joe' or 'analyst_jane'
-  - name: "analyst_*"
+  - name: "analyst_named"
+    is_wildcarded: true
     to_cluster: "default"
     to_user: "analyst_*"
   # normal user

--- a/config/testdata/full.yml
+++ b/config/testdata/full.yml
@@ -266,8 +266,20 @@ clusters:
         max_queue_time: 70s
         allowed_networks: ["office"]
 
-  - name: "thrid cluster"
-    nodes: ["thrid1:8123", "thrid2:8123"]
+    heartbeat:
+      # Username for heartbeats
+      # No default value
+      # If ommited (by default),
+      # credentials of the first user in clusters.users will be used for heart beat requests to clickhouse.
+      # Note, that credentials of a wildcarded user cannot be used for heat beat
+      user: "hbuser"
+
+      # Password for heartbeats
+      # No default value
+      password: "hbpassword"
+
+  - name: "third cluster"
+    nodes: ["third1:8123", "third2:8123"]
 
     # User configuration for heart beat requests.
     # Credentials of the first user in clusters.users will be used for heart beat requests to clickhouse.
@@ -282,19 +294,8 @@ clusters:
 
       # The parameter to set the URI to request in a health check
       # By default "/ping"
-      request: "/ping"
+      request: "/?query=SELECT%201"
 
       # Reference response from clickhouse on health check request
       # By default "Ok.\n"
       response: "Ok.\n"
-
-      # Username for heartbeats
-      # No default value
-      # If ommited (by default),
-      # credentials of the first user in clusters.users will be used for heart beat requests to clickhouse.
-      # Note, that credentials of a wildcarded user cannot be used for heat beat
-      name: "hbuser"
-
-      # Password for heartbeats
-      # No default value
-      password: "hbpassword"

--- a/config/testdata/full.yml
+++ b/config/testdata/full.yml
@@ -287,3 +287,14 @@ clusters:
       # Reference response from clickhouse on health check request
       # By default "Ok.\n"
       response: "Ok.\n"
+
+      # Username for heartbeats
+      # No default value
+      # If ommited (by default),
+      # credentials of the first user in clusters.users will be used for heart beat requests to clickhouse.
+      # Note, that credentials of a wildcarded user cannot be used for heat beat
+      name: "hbuser"
+
+      # Password for heartbeats
+      # No default value
+      password: "hbpassword"

--- a/docs/content/en/configuration/users.md
+++ b/docs/content/en/configuration/users.md
@@ -15,4 +15,5 @@ Requests to `chproxy` must be authorized with credentials from [user_config](htt
 
 Limits for `in-users` and `out-users` are independent.
 
-
+`in-users` with `is_wildcarded` flag `true` have names that look like `<prefix>_*` (e.g `analyst_*`).
+Asterisk matches a sequence of valid characters (except underscore) in user name in request to `chproxy`. `chproxy` serves wildcarded users in a normal way, except their credentials from incoming requests are resent to ClickHouse as they are, passwords and names of `out-users` are not used for communications with ClickHouse.

--- a/docs/content/en/use-cases/wildcarded.md
+++ b/docs/content/en/use-cases/wildcarded.md
@@ -17,6 +17,7 @@ users:
   - name: "analyst_*"
     to_cluster: "default"
     to_user: "analyst_*"
+    is_wildcarded: true
   - name: "dba"
     password: "dba_ingress_pass"
     to_cluster: "default"

--- a/docs/content/en/use-cases/wildcarded.md
+++ b/docs/content/en/use-cases/wildcarded.md
@@ -1,0 +1,35 @@
+---
+title: Pass user names and passwords as is
+menuTitle: Wildcarded users
+category: Use Cases
+position: 305
+---
+
+Suppose you need to use `ClickHouse` LDAP facilities. It is more secure and more flexible than having credentials hardcoded in ClickHouse or a `chproxy` configuration files.
+The following `chproxy` config may be used for [this use case](https://github.com/ContentSquare/chproxy/blob/master/config/examples/wildcarded.yml):
+```yml
+log_debug: true
+
+users:
+  # wildcarded user
+  # matches with any name with prefix 'analyst_'
+  # e.g. 'analyst_joe' or 'analyst_jane'
+  - name: "analyst_*"
+    to_cluster: "default"
+    to_user: "analyst_*"
+  - name: "dba"
+    password: "dba_ingress_pass"
+    to_cluster: "default"
+    to_user: "dba"
+clusters:
+  - name: "default"
+    nodes: ["127.0.0.1:8123"]
+
+    users:
+    - name: "analyst_*"
+    - name: "dba"
+      password: "dba_egress_pass"
+```
+
+Wildcarded user has "_*" suffix.
+Original name and original password are used in requests to ClickHouse

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -19,6 +19,9 @@ type heartBeat struct {
 	password string
 }
 
+// User credentials are not needed
+const pingStr string = "/ping"
+
 func newHeartBeat(c config.HeartBeat, firstClusterUser config.ClusterUser) *heartBeat {
 	newHB := &heartBeat{
 		interval: time.Duration(c.Interval),
@@ -26,7 +29,7 @@ func newHeartBeat(c config.HeartBeat, firstClusterUser config.ClusterUser) *hear
 		request:  c.Request,
 		response: c.Response,
 	}
-	if c.Request != "/ping" {
+	if c.Request != pingStr {
 		if len(c.User) > 0 {
 			newHB.user = c.User
 			newHB.password = c.Password
@@ -43,7 +46,7 @@ func (hb *heartBeat) isHealthy(addr string) error {
 	if err != nil {
 		return err
 	}
-	if hb.request != "/ping" && hb.user != "" {
+	if hb.request != pingStr && hb.user != "" {
 		req.SetBasicAuth(hb.user, hb.password)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), hb.timeout)

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/contentsquare/chproxy/config"
-	"github.com/contentsquare/chproxy/log"
 )
 
 type heartBeat struct {
@@ -38,13 +37,11 @@ func newHeartBeat(c config.HeartBeat, firstClusterUser config.ClusterUser) *hear
 }
 
 func (hb *heartBeat) isHealthy(addr string) error {
-	log.Debugf("User %s used for heartbeat", hb.user)
 	req, err := http.NewRequest("GET", addr+hb.request, nil)
 	if err != nil {
 		return err
 	}
 	if hb.request != "/ping" && hb.user != "" {
-		log.Debugf("basic auth")
 		req.SetBasicAuth(hb.user, hb.password)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), hb.timeout)

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -26,7 +26,7 @@ func newHeartBeat(c config.HeartBeat, firstClusterUser config.ClusterUser) *hear
 		request:  c.Request,
 		response: c.Response,
 	}
-	if c.UserNeeded {
+	if c.Request != "/ping" {
 		if len(c.User) > 0 {
 			newHB.user = c.User
 			newHB.password = c.Password

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -26,12 +26,14 @@ func newHeartBeat(c config.HeartBeat, firstClusterUser config.ClusterUser) *hear
 		request:  c.Request,
 		response: c.Response,
 	}
-	if len(c.Name) > 0 {
-		newHB.user = c.Name
-		newHB.password = c.Password
-	} else {
-		newHB.user = firstClusterUser.Name
-		newHB.password = firstClusterUser.Password
+	if c.UserNeeded {
+		if len(c.User) > 0 {
+			newHB.user = c.User
+			newHB.password = c.Password
+		} else {
+			newHB.user = firstClusterUser.Name
+			newHB.password = firstClusterUser.Password
+		}
 	}
 	return newHB
 }

--- a/heartbeat_test.go
+++ b/heartbeat_test.go
@@ -61,6 +61,15 @@ var (
 		Request:  "/wrongQuery",
 		Response: "Ok.\n",
 	}
+
+	heartBeatWrongNamedCfg = config.HeartBeat{
+		Interval: config.Duration(20 * time.Second),
+		Timeout:  config.Duration(30 * time.Second),
+		Request:  "/ping",
+		Response: "Ok.\n",
+		Name:     "hbuser",
+		Password: "hbpassword",
+	}
 )
 
 func TestNewHeartBeat(t *testing.T) {
@@ -90,6 +99,10 @@ func TestNewHeartBeat(t *testing.T) {
 		t.Fatalf("heartbeat error expected")
 	}
 	testCompareStr(t, "heartbeat error", check.Error(), "unexpected response: wrong\n")
+
+	hbNameWrong := newHeartBeat(heartBeatWrongNamedCfg, clusterCfg.ClusterUsers[0])
+	testCompareStr(t, "heartbeat.user", hbNameWrong.user, "hbuser")
+	testCompareStr(t, "heartbeat.password", hbNameWrong.password, "hbpassword")
 }
 
 func testCompareNum(t *testing.T, name string, value int64, expected int64) {

--- a/heartbeat_test.go
+++ b/heartbeat_test.go
@@ -61,29 +61,26 @@ var (
 	}
 
 	heartBeatFullCfg = config.HeartBeat{
-		Interval:   config.Duration(20 * time.Second),
-		Timeout:    config.Duration(30 * time.Second),
-		Request:    "/?query=SELECT%201",
-		Response:   "Ok.\n",
-		UserNeeded: true,
+		Interval: config.Duration(20 * time.Second),
+		Timeout:  config.Duration(30 * time.Second),
+		Request:  "/?query=SELECT%201",
+		Response: "Ok.\n",
 	}
 
 	heartBeatWrongResponseCfg = config.HeartBeat{
-		Interval:   config.Duration(20 * time.Second),
-		Timeout:    config.Duration(30 * time.Second),
-		Request:    "/wrongQuery",
-		Response:   "Ok.\n",
-		UserNeeded: true,
+		Interval: config.Duration(20 * time.Second),
+		Timeout:  config.Duration(30 * time.Second),
+		Request:  "/wrongQuery",
+		Response: "Ok.\n",
 	}
 
 	heartBeatWrongNamedCfg = config.HeartBeat{
-		Interval:   config.Duration(20 * time.Second),
-		Timeout:    config.Duration(30 * time.Second),
-		Request:    "/?query=SELECT%201",
-		Response:   "Ok.\n",
-		User:       "hbuser",
-		Password:   "hbpassword",
-		UserNeeded: true,
+		Interval: config.Duration(20 * time.Second),
+		Timeout:  config.Duration(30 * time.Second),
+		Request:  "/?query=SELECT%201",
+		Response: "Ok.\n",
+		User:     "hbuser",
+		Password: "hbpassword",
 	}
 )
 

--- a/heartbeat_test.go
+++ b/heartbeat_test.go
@@ -13,7 +13,19 @@ import (
 var (
 	hbHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/ping" {
-			fmt.Fprintln(w, "Ok.")
+			if _, _, found := r.BasicAuth(); !found {
+				fmt.Fprintln(w, "Ok.")
+			} else {
+				fmt.Fprintln(w, "User is not expected.")
+			}
+			return
+		}
+		if r.URL.Path == "/" && r.URL.Query().Get("query") == "SELECT 1" {
+			if _, _, found := r.BasicAuth(); found {
+				fmt.Fprintln(w, "Ok.")
+			} else {
+				fmt.Fprintln(w, "User is required.")
+			}
 			return
 		}
 		qid := r.URL.Query().Get("query")
@@ -49,26 +61,29 @@ var (
 	}
 
 	heartBeatFullCfg = config.HeartBeat{
-		Interval: config.Duration(20 * time.Second),
-		Timeout:  config.Duration(30 * time.Second),
-		Request:  "/ping",
-		Response: "Ok.\n",
+		Interval:   config.Duration(20 * time.Second),
+		Timeout:    config.Duration(30 * time.Second),
+		Request:    "/?query=SELECT%201",
+		Response:   "Ok.\n",
+		UserNeeded: true,
 	}
 
 	heartBeatWrongResponseCfg = config.HeartBeat{
-		Interval: config.Duration(20 * time.Second),
-		Timeout:  config.Duration(30 * time.Second),
-		Request:  "/wrongQuery",
-		Response: "Ok.\n",
+		Interval:   config.Duration(20 * time.Second),
+		Timeout:    config.Duration(30 * time.Second),
+		Request:    "/wrongQuery",
+		Response:   "Ok.\n",
+		UserNeeded: true,
 	}
 
 	heartBeatWrongNamedCfg = config.HeartBeat{
-		Interval: config.Duration(20 * time.Second),
-		Timeout:  config.Duration(30 * time.Second),
-		Request:  "/ping",
-		Response: "Ok.\n",
-		Name:     "hbuser",
-		Password: "hbpassword",
+		Interval:   config.Duration(20 * time.Second),
+		Timeout:    config.Duration(30 * time.Second),
+		Request:    "/?query=SELECT%201",
+		Response:   "Ok.\n",
+		User:       "hbuser",
+		Password:   "hbpassword",
+		UserNeeded: true,
 	}
 )
 
@@ -82,7 +97,7 @@ func TestNewHeartBeat(t *testing.T) {
 	hb := newHeartBeat(heartBeatFullCfg, clusterCfg.ClusterUsers[0])
 	testCompareNum(t, "heartbeat.interval", int64(hb.interval/time.Microsecond), int64(time.Duration(20*time.Second)/time.Microsecond))
 	testCompareNum(t, "heartbeat.timeout", int64(hb.timeout/time.Microsecond), int64(time.Duration(30*time.Second)/time.Microsecond))
-	testCompareStr(t, "heartbeat.request", hb.request, "/ping")
+	testCompareStr(t, "heartbeat.request", hb.request, "/?query=SELECT%201")
 	testCompareStr(t, "heartbeat.response", hb.response, "Ok.\n")
 	testCompareStr(t, "heartbeat.user", hb.user, "web")
 	testCompareStr(t, "heartbeat.password", hb.password, "123")

--- a/proxy.go
+++ b/proxy.go
@@ -582,11 +582,8 @@ func (rp *reverseProxy) getUser(name string, password string) (found bool, u *us
 	found = false
 	u = rp.users[name]
 	if u != nil {
-		// c and cu for toCluster and toUser must exist if applyConfig
-		// is correct.
-		// Fix applyConfig if c or cu equal to nil.
-
 		found = (u.password == password)
+		// existence of c and cu for toCluster is guaranteed by applyConfig
 		c = rp.clusters[u.toCluster]
 		cu = c.users[u.toUser]
 	} else {

--- a/proxy.go
+++ b/proxy.go
@@ -469,7 +469,7 @@ func (rp *reverseProxy) applyConfig(cfg *config.Config) error {
 			transactionsTimeout = user.MaxExecutionTime
 		}
 		if user.IsWildcarded {
-			cfg.HasWildcarded = true
+			rp.hasWildcarded = true
 		}
 	}
 
@@ -572,7 +572,6 @@ func (rp *reverseProxy) applyConfig(cfg *config.Config) error {
 	rp.lock.Lock()
 	rp.clusters = clusters
 	rp.users = users
-	rp.hasWildcarded = cfg.HasWildcarded
 	// Swap is needed for deferred closing of old caches.
 	// See the code above where new caches are created.
 	caches, rp.caches = rp.caches, caches

--- a/proxy.go
+++ b/proxy.go
@@ -516,7 +516,7 @@ func (rp *reverseProxy) applyConfig(cfg *config.Config) error {
 		cu := cl.users[cuname]
 
 		if cu.isWildcarded {
-			if heartbeat.UserNeeded && len(heartbeat.User) == 0 {
+			if heartbeat.Request != "/ping" && len(heartbeat.User) == 0 {
 				return fmt.Errorf("`cluster.heartbeat.user ` cannot be unset for %q because a wildcarded user cannot send heartbeat", clname)
 			}
 		}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -133,8 +133,7 @@ var badCfgWithNoHeartBeatUser = &config.Config{
 				},
 			},
 			HeartBeat: config.HeartBeat{
-				Request:    "/not_ping",
-				UserNeeded: true,
+				Request: "/not_ping",
 			},
 		},
 	},


### PR DESCRIPTION
## Description

Implements Wildcarded users concept https://hackmd.io/LXk8tLI8Q3etKax-HWtGxQ
as agreed in https://github.com/ContentSquare/chproxy/pull/170

The idea is to have chproxy users with a suffix, that is out if chproxy control,
like analyst_* . 
For such users password from request to chproxy is retransmitted to ClickHouse as is.
So, analyst_jane and analyst_bob can send their requests to ClickHouse.

Rationale:  avoid nececity to have all users listed in chproxy config, ability to use LDAP or kerberos facilities at ClickHouse side.

## Pull request type

Please check the type of change your PR introduces:
- [x ] Feature

### Checklist

- [ x] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [x ] All tests passing
- [ x] Extended the README / documentation, if necessary

golangci-lint 1.49.0 reports several errors that are not related to the change
## Does this introduce a breaking change?

 [x ] No

## Further comments

I need some advice on how to add a test that actually covers the new functionality