### PR TITLE
enh(concurrent-queries): propagate errors for failed transactions

### DIFF
--- a/cache/async_cache.go
+++ b/cache/async_cache.go
@@ -34,7 +34,7 @@ func (c *AsyncCache) Close() error {
 	return nil
 }
 
-func (c *AsyncCache) AwaitForConcurrentTransaction(key *Key) (TransactionState, error) {
+func (c *AsyncCache) AwaitForConcurrentTransaction(key *Key) (TransactionStatus, error) {
 	startTime := time.Now()
 	seenState := transactionAbsent
 	for {
@@ -42,17 +42,17 @@ func (c *AsyncCache) AwaitForConcurrentTransaction(key *Key) (TransactionState, 
 		if elapsedTime > c.graceTime {
 			// The entry didn't appear during deadline.
 			// Let the caller creating it.
-			return seenState, nil
+			return TransactionStatus{State: seenState}, nil
 		}
 
-		state, err := c.TransactionRegistry.Status(key)
+		status, err := c.TransactionRegistry.Status(key)
 
 		if err != nil {
-			return seenState, err
+			return TransactionStatus{State: seenState}, err
 		}
 
-		if !state.IsPending() {
-			return state, nil
+		if !status.State.IsPending() {
+			return status, nil
 		}
 
 		// Wait for deadline in the hope the entry will appear

--- a/cache/key.go
+++ b/cache/key.go
@@ -10,7 +10,7 @@ import (
 
 // Version must be increased with each backward-incompatible change
 // in the cache storage.
-const Version = 4
+const Version = 5
 
 // Key is the key for use in the cache.
 type Key struct {

--- a/cache/transaction_registry.go
+++ b/cache/transaction_registry.go
@@ -15,13 +15,18 @@ type TransactionRegistry interface {
 	Complete(key *Key) error
 
 	// Fail fails a transaction for given key
-	Fail(key *Key) error
+	Fail(key *Key, reason string) error
 
 	// Status checks the status of the transaction
-	Status(key *Key) (TransactionState, error)
+	Status(key *Key) (TransactionStatus, error)
 }
 
-type TransactionState uint64
+type TransactionStatus struct {
+	State      TransactionState
+	FailReason string // filled in only if state of transaction is transactionFailed
+}
+
+type TransactionState uint8
 
 const (
 	transactionCreated   TransactionState = 0

--- a/cache/transaction_registry_redis.go
+++ b/cache/transaction_registry_redis.go
@@ -62,7 +62,7 @@ func (r *redisTransactionRegistry) Status(key *Key) (TransactionStatus, error) {
 
 	state := TransactionState(uint8(raw[0]))
 	var reason string
-	if state.IsFailed() {
+	if state.IsFailed() && len(raw) > 1 {
 		reason = string(raw[1:])
 	}
 	return TransactionStatus{State: state, FailReason: reason}, nil

--- a/cache/transaction_registry_redis.go
+++ b/cache/transaction_registry_redis.go
@@ -25,33 +25,47 @@ func newRedisTransactionRegistry(redisClient redis.UniversalClient, deadline tim
 }
 
 func (r *redisTransactionRegistry) Create(key *Key) error {
-	return r.redisClient.Set(context.Background(), toTransactionKey(key), uint64(transactionCreated), r.deadline).Err()
+	return r.redisClient.Set(context.Background(), toTransactionKey(key),
+		[]byte{uint8(transactionCreated)}, r.deadline).Err()
 }
 
 func (r *redisTransactionRegistry) Complete(key *Key) error {
-	return r.updateTransactionState(key, transactionCompleted)
+	return r.updateTransactionState(key, []byte{uint8(transactionCompleted)})
 }
 
-func (r *redisTransactionRegistry) Fail(key *Key) error {
-	return r.updateTransactionState(key, transactionFailed)
+func (r *redisTransactionRegistry) Fail(key *Key, reason string) error {
+	b := make([]byte, 0, uint32(len(reason))+1)
+	b = append(b, byte(transactionFailed))
+	b = append(b, []byte(reason)...)
+	return r.updateTransactionState(key, b)
 }
 
-func (r *redisTransactionRegistry) updateTransactionState(key *Key, state TransactionState) error {
-	return r.redisClient.Set(context.Background(), toTransactionKey(key), uint64(state), r.deadline).Err()
+func (r *redisTransactionRegistry) updateTransactionState(key *Key, value []byte) error {
+	return r.redisClient.Set(context.Background(), toTransactionKey(key), value, r.deadline).Err()
 }
 
-func (r *redisTransactionRegistry) Status(key *Key) (TransactionState, error) {
-	state, err := r.redisClient.Get(context.Background(), toTransactionKey(key)).Uint64()
+func (r *redisTransactionRegistry) Status(key *Key) (TransactionStatus, error) {
+	raw, err := r.redisClient.Get(context.Background(), toTransactionKey(key)).Bytes()
 	if errors.Is(err, redis.Nil) {
-		return transactionAbsent, nil
+		return TransactionStatus{State: transactionAbsent}, nil
 	}
 
 	if err != nil {
 		log.Errorf("Failed to fetch transaction status from redis for key: %s", key.String())
-		return transactionAbsent, err
+		return TransactionStatus{State: transactionAbsent}, err
 	}
 
-	return TransactionState(state), nil
+	if len(raw) == 0 {
+		log.Errorf("Failed to fetch transaction status from redis raw value: %s", key.String())
+		return TransactionStatus{State: transactionAbsent}, err
+	}
+
+	state := TransactionState(uint8(raw[0]))
+	var reason string
+	if state.IsFailed() {
+		reason = string(raw[1:])
+	}
+	return TransactionStatus{State: state, FailReason: reason}, nil
 }
 
 func (r *redisTransactionRegistry) Close() error {

--- a/cache/transaction_registry_redis_test.go
+++ b/cache/transaction_registry_redis_test.go
@@ -27,7 +27,7 @@ func TestRedisTransaction(t *testing.T) {
 	}
 
 	status, err := redisTransaction.Status(key)
-	if err != nil || !status.IsPending() {
+	if err != nil || !status.State.IsPending() {
 		t.Fatalf("unexpected: transaction should be pending")
 	}
 
@@ -36,7 +36,46 @@ func TestRedisTransaction(t *testing.T) {
 	}
 
 	status, err = redisTransaction.Status(key)
-	if err != nil || !status.IsCompleted() {
+	if err != nil || !status.State.IsCompleted() {
 		t.Fatalf("unexpected: transaction should be done")
+	}
+}
+
+func TestFailRedisTransaction(t *testing.T) {
+	s := miniredis.RunT(t)
+
+	redisClient := redis.NewUniversalClient(&redis.UniversalOptions{
+		Addrs: []string{s.Addr()},
+	})
+
+	graceTime := 10 * time.Second
+	key := &Key{
+		Query: []byte("SELECT pending entries"),
+	}
+
+	redisTransaction := newRedisTransactionRegistry(redisClient, graceTime)
+
+	if err := redisTransaction.Create(key); err != nil {
+		t.Fatalf("unexpected error: %s while registering new transaction", err)
+	}
+
+	status, err := redisTransaction.Status(key)
+	if err != nil || !status.State.IsPending() {
+		t.Fatalf("unexpected: transaction should be pending")
+	}
+
+	failReason := "failed for fun dudes"
+
+	if err := redisTransaction.Fail(key, failReason); err != nil {
+		t.Fatalf("unexpected error: %s while unregistering transaction", err)
+	}
+
+	status, err = redisTransaction.Status(key)
+	if err != nil || !status.State.IsFailed() {
+		t.Fatalf("unexpected: transaction should be failed")
+	}
+
+	if status.FailReason != failReason {
+		t.Fatalf("unexpected: transaction should curry fail reason")
 	}
 }

--- a/cache/transaction_registry_test.go
+++ b/cache/transaction_registry_test.go
@@ -17,7 +17,7 @@ func TestInMemoryTransaction(t *testing.T) {
 	}
 
 	status, err := inMemoryTransaction.Status(key)
-	if err != nil || !status.IsPending() {
+	if err != nil || !status.State.IsPending() {
 		t.Fatalf("unexpected: transaction should be pending")
 	}
 
@@ -26,7 +26,7 @@ func TestInMemoryTransaction(t *testing.T) {
 	}
 
 	status, err = inMemoryTransaction.Status(key)
-	if err != nil || !status.IsCompleted() {
+	if err != nil || !status.State.IsCompleted() {
 		t.Fatalf("unexpected: transaction should be done")
 	}
 

--- a/docs/content/en/index.md
+++ b/docs/content/en/index.md
@@ -24,7 +24,7 @@ Chproxy, is an HTTP proxy and load balancer for [ClickHouse](https://ClickHouse.
 - All the limits may be independently set for each input user and for each per-cluster user.
 - May delay request execution until it fits per-user limits.
 - Per-user [response caching](/configuration/caching) may be configured.
-- Response caches have built-in protection against [thundering herd](https://en.wikipedia.org/wiki/Cache_stampede) problem aka `dogpile effect`.
+- Response caches have built-in protection against [thundering herd](https://en.wikipedia.org/wiki/Cache_stampede) problem aka `dogpile effect`. More information can be found in [Thundering herd](/configuration/caching).
 - Evenly spreads requests among replicas and nodes using `least loaded` + `round robin` technique.
 - Monitors node health and prevents from sending requests to unhealthy nodes.
 - Supports automatic HTTPS certificate issuing and renewal via [Let’s Encrypt](https://letsencrypt.org/).

--- a/main_test.go
+++ b/main_test.go
@@ -680,7 +680,7 @@ func TestServe(t *testing.T) {
 				// scenario: 1st query fails before grace_time elapsed. 2nd query fails as well.
 
 				q := "SELECT ERROR"
-				executeTwoConcurrentRequests(t, q, http.StatusInternalServerError, http.StatusInternalServerError, "DB::Exception\n", "concurrent query failed")
+				executeTwoConcurrentRequests(t, q, http.StatusInternalServerError, http.StatusInternalServerError, "DB::Exception\n", "DB::Exception\n")
 			},
 			startHTTP,
 		},

--- a/main_test.go
+++ b/main_test.go
@@ -680,7 +680,7 @@ func TestServe(t *testing.T) {
 				// scenario: 1st query fails before grace_time elapsed. 2nd query fails as well.
 
 				q := "SELECT ERROR"
-				executeTwoConcurrentRequests(t, q, http.StatusInternalServerError, http.StatusInternalServerError, "DB::Exception\n", "DB::Exception\n")
+				executeTwoConcurrentRequests(t, q, http.StatusInternalServerError, http.StatusInternalServerError, "DB::Exception\n", "[concurrent query failed] DB::Exception\n")
 			},
 			startHTTP,
 		},

--- a/proxy.go
+++ b/proxy.go
@@ -423,7 +423,7 @@ func toString(stream io.Reader) (string, error) {
 // clickhouseRecoverableStatusCodes set of recoverable http responses' status codes from Clickhouse.
 // When such happens we mark transaction as completed and let concurrent query to hit another Clickhouse shard.
 // possible http error codes in clickhouse (i.e: https://github.com/ClickHouse/ClickHouse/blob/master/src/Server/HTTPHandler.cpp)
-var clickhouseRecoverableStatusCodes = map[int]struct{}{http.StatusServiceUnavailable: {}}
+var clickhouseRecoverableStatusCodes = map[int]struct{}{http.StatusServiceUnavailable: {}, http.StatusRequestTimeout: {}}
 
 func (rp *reverseProxy) completeTransaction(s *scope, statusCode int, userCache *cache.AsyncCache, key *cache.Key,
 	q []byte,

--- a/proxy.go
+++ b/proxy.go
@@ -23,6 +23,9 @@ import (
 // tmpDir temporary path to store ongoing queries results
 const tmpDir = "/tmp"
 
+// failedTransactionPrefix prefix added to the failed reason for concurrent queries registry
+const failedTransactionPrefix = "[concurrent query failed]"
+
 type reverseProxy struct {
 	rp *httputil.ReverseProxy
 
@@ -353,7 +356,8 @@ func (rp *reverseProxy) serveFromCache(s *scope, srw *statResponseWriter, req *h
 			log.Errorf("%s failed to get error reason: %s", s, err.Error())
 		}
 
-		rp.completeTransaction(s, statusCode, userCache, key, q, errString)
+		errReason := fmt.Sprintf("%s %s", failedTransactionPrefix, errString)
+		rp.completeTransaction(s, statusCode, userCache, key, q, errReason)
 
 		// we need to reset the offset since the reader of tmpFileRespWriter was already
 		// consumed in RespondWithData(...)


### PR DESCRIPTION
## Description

Fix for the issue reported in https://github.com/ContentSquare/chproxy/issues/224

<!--  Please explain the object of this PR and the changes you made.
A reference to a github issue would be appreciated. --> 

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [ ] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Further comments

- Failure reason is fully copied to memory as it should not curry any data which size is negligble
- Added 408 status code to the recoverable errors
- Following the comment under the linked issue, perhaps it's worth to update a ttl of transaction while updating it to ~1 second. This way only awaiting transactions would not reach clickhouse, but at least further recoverable calls (but not identified) would be able to retry. I didn't include it in the PR, I mention it for the sake of discussion  

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
