### PR TITLE
Update TTL of transactions upon finalisation to 500 ms

### DIFF
--- a/cache/async_cache.go
+++ b/cache/async_cache.go
@@ -91,12 +91,12 @@ func NewAsyncCache(cfg config.Cache, maxExecutionTime time.Duration) (*AsyncCach
 	switch cfg.Mode {
 	case "file_system":
 		cache, err = newFilesSystemCache(cfg, graceTime)
-		transaction = newInMemoryTransactionRegistry(transactionDeadline)
+		transaction = newInMemoryTransactionRegistry(transactionDeadline, transactionEndedTTL)
 	case "redis":
 		var redisClient redis.UniversalClient
 		redisClient, err = clients.NewRedisClient(cfg.Redis)
 		cache = newRedisCache(redisClient, cfg)
-		transaction = newRedisTransactionRegistry(redisClient, transactionDeadline)
+		transaction = newRedisTransactionRegistry(redisClient, transactionDeadline, transactionEndedTTL)
 	default:
 		return nil, fmt.Errorf("unknown config mode")
 	}

--- a/cache/async_cache_test.go
+++ b/cache/async_cache_test.go
@@ -15,7 +15,7 @@ const asyncTestDir = "./async-test-data"
 
 func TestAsyncCache_Cleanup_Of_Expired_Transactions(t *testing.T) {
 	graceTime := 100 * time.Millisecond
-	asyncCache := newAsyncTestCache(t, graceTime)
+	asyncCache := newAsyncTestCache(t, graceTime, graceTime/2)
 	defer func() {
 		asyncCache.Close()
 		os.RemoveAll(asyncTestDir)
@@ -51,7 +51,7 @@ func TestAsyncCache_Cleanup_Of_Expired_Transactions(t *testing.T) {
 
 func TestAsyncCache_AwaitForConcurrentTransaction_GraceTimeWithoutTransactionCompletion(t *testing.T) {
 	graceTime := 100 * time.Millisecond
-	asyncCache := newAsyncTestCache(t, graceTime)
+	asyncCache := newAsyncTestCache(t, graceTime, graceTime/2)
 
 	defer func() {
 		asyncCache.Close()
@@ -94,7 +94,7 @@ func TestAsyncCache_AwaitForConcurrentTransaction_GraceTimeWithoutTransactionCom
 
 func TestAsyncCache_AwaitForConcurrentTransaction_TransactionCompletedWhileAwaiting(t *testing.T) {
 	graceTime := 300 * time.Millisecond
-	asyncCache := newAsyncTestCache(t, graceTime)
+	asyncCache := newAsyncTestCache(t, graceTime, graceTime/2)
 
 	defer func() {
 		asyncCache.Close()
@@ -138,7 +138,7 @@ func TestAsyncCache_AwaitForConcurrentTransaction_TransactionCompletedWhileAwait
 
 func TestAsyncCache_AwaitForConcurrentTransaction_TransactionFailedWhileAwaiting(t *testing.T) {
 	graceTime := 300 * time.Millisecond
-	asyncCache := newAsyncTestCache(t, graceTime)
+	asyncCache := newAsyncTestCache(t, graceTime, graceTime/2)
 
 	defer func() {
 		asyncCache.Close()
@@ -186,7 +186,7 @@ func TestAsyncCache_AwaitForConcurrentTransaction_TransactionFailedWhileAwaiting
 	}
 }
 
-func newAsyncTestCache(t *testing.T, graceTime time.Duration) *AsyncCache {
+func newAsyncTestCache(t *testing.T, graceTime, transactionEndedTime time.Duration) *AsyncCache {
 	t.Helper()
 	cfg := config.Cache{
 		Name: "foobar",
@@ -203,7 +203,7 @@ func newAsyncTestCache(t *testing.T, graceTime time.Duration) *AsyncCache {
 
 	asyncC := &AsyncCache{
 		Cache:               c,
-		TransactionRegistry: newInMemoryTransactionRegistry(graceTime),
+		TransactionRegistry: newInMemoryTransactionRegistry(graceTime, transactionEndedTime),
 		graceTime:           graceTime,
 	}
 	return asyncC

--- a/cache/transaction_registry.go
+++ b/cache/transaction_registry.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"io"
+	"time"
 )
 
 // TransactionRegistry is a registry of ongoing queries identified by Key.
@@ -20,6 +21,9 @@ type TransactionRegistry interface {
 	// Status checks the status of the transaction
 	Status(key *Key) (TransactionStatus, error)
 }
+
+// transactionEndedTTL amount of time transaction record is kept after being updated
+const transactionEndedTTL = 500 * time.Millisecond
 
 type TransactionStatus struct {
 	State      TransactionState

--- a/cache/transaction_registry_redis_test.go
+++ b/cache/transaction_registry_redis_test.go
@@ -20,7 +20,7 @@ func TestRedisTransaction(t *testing.T) {
 		Query: []byte("SELECT pending entries"),
 	}
 
-	redisTransaction := newRedisTransactionRegistry(redisClient, graceTime)
+	redisTransaction := newRedisTransactionRegistry(redisClient, graceTime, graceTime)
 
 	if err := redisTransaction.Create(key); err != nil {
 		t.Fatalf("unexpected error: %s while registering new transaction", err)
@@ -53,7 +53,7 @@ func TestFailRedisTransaction(t *testing.T) {
 		Query: []byte("SELECT pending entries"),
 	}
 
-	redisTransaction := newRedisTransactionRegistry(redisClient, graceTime)
+	redisTransaction := newRedisTransactionRegistry(redisClient, graceTime, graceTime)
 
 	if err := redisTransaction.Create(key); err != nil {
 		t.Fatalf("unexpected error: %s while registering new transaction", err)
@@ -77,5 +77,53 @@ func TestFailRedisTransaction(t *testing.T) {
 
 	if status.FailReason != failReason {
 		t.Fatalf("unexpected: transaction should curry fail reason")
+	}
+}
+
+func TestCleanupRedisTransaction(t *testing.T) {
+	s := miniredis.RunT(t)
+
+	redisClient := redis.NewUniversalClient(&redis.UniversalOptions{
+		Addrs: []string{s.Addr()},
+	})
+
+	graceTime := 10 * time.Second
+	updatedTTL := 10 * time.Millisecond
+	key := &Key{
+		Query: []byte("SELECT pending entries"),
+	}
+
+	redisTransaction := newRedisTransactionRegistry(redisClient, graceTime, updatedTTL)
+
+	if err := redisTransaction.Create(key); err != nil {
+		t.Fatalf("unexpected error: %s while registering new transaction", err)
+	}
+
+	status, err := redisTransaction.Status(key)
+	if err != nil || !status.State.IsPending() {
+		t.Fatalf("unexpected: transaction should be pending")
+	}
+
+	failReason := "failed for fun dudes"
+
+	if err := redisTransaction.Fail(key, failReason); err != nil {
+		t.Fatalf("unexpected error: %s while unregistering transaction", err)
+	}
+
+	status, err = redisTransaction.Status(key)
+	if err != nil || !status.State.IsFailed() {
+		t.Fatalf("unexpected: transaction should be failed")
+	}
+
+	if status.FailReason != failReason {
+		t.Fatalf("unexpected: transaction should curry fail reason")
+	}
+
+	// move ttls of mini redis to trigger the clean up transaction
+	s.FastForward(updatedTTL)
+
+	status, err = redisTransaction.Status(key)
+	if err != nil || !status.State.IsAbsent() {
+		t.Fatalf("unexpected: transaction should be cleaned up")
 	}
 }

--- a/cache/transaction_registry_redis_test.go
+++ b/cache/transaction_registry_redis_test.go
@@ -80,7 +80,7 @@ func TestFailRedisTransaction(t *testing.T) {
 	}
 }
 
-func TestCleanupRedisTransaction(t *testing.T) {
+func TestCleanupFailedRedisTransaction(t *testing.T) {
 	s := miniredis.RunT(t)
 
 	redisClient := redis.NewUniversalClient(&redis.UniversalOptions{
@@ -117,6 +117,48 @@ func TestCleanupRedisTransaction(t *testing.T) {
 
 	if status.FailReason != failReason {
 		t.Fatalf("unexpected: transaction should curry fail reason")
+	}
+
+	// move ttls of mini redis to trigger the clean up transaction
+	s.FastForward(updatedTTL)
+
+	status, err = redisTransaction.Status(key)
+	if err != nil || !status.State.IsAbsent() {
+		t.Fatalf("unexpected: transaction should be cleaned up")
+	}
+}
+
+func TestCleanupCompletedRedisTransaction(t *testing.T) {
+	s := miniredis.RunT(t)
+
+	redisClient := redis.NewUniversalClient(&redis.UniversalOptions{
+		Addrs: []string{s.Addr()},
+	})
+
+	graceTime := 10 * time.Second
+	updatedTTL := 10 * time.Millisecond
+	key := &Key{
+		Query: []byte("SELECT pending entries"),
+	}
+
+	redisTransaction := newRedisTransactionRegistry(redisClient, graceTime, updatedTTL)
+
+	if err := redisTransaction.Create(key); err != nil {
+		t.Fatalf("unexpected error: %s while registering new transaction", err)
+	}
+
+	status, err := redisTransaction.Status(key)
+	if err != nil || !status.State.IsPending() {
+		t.Fatalf("unexpected: transaction should be pending")
+	}
+
+	if err := redisTransaction.Complete(key); err != nil {
+		t.Fatalf("unexpected error: %s while unregistering transaction", err)
+	}
+
+	status, err = redisTransaction.Status(key)
+	if err != nil || !status.State.IsCompleted() {
+		t.Fatalf("unexpected: transaction should be failed")
 	}
 
 	// move ttls of mini redis to trigger the clean up transaction

--- a/cache/transaction_registry_test.go
+++ b/cache/transaction_registry_test.go
@@ -10,7 +10,7 @@ func TestInMemoryTransaction(t *testing.T) {
 	key := &Key{
 		Query: []byte("SELECT pending entries"),
 	}
-	inMemoryTransaction := newInMemoryTransactionRegistry(graceTime)
+	inMemoryTransaction := newInMemoryTransactionRegistry(graceTime, graceTime)
 
 	if err := inMemoryTransaction.Create(key); err != nil {
 		t.Fatalf("unexpected error: %s while registering new transaction", err)

--- a/proxy.go
+++ b/proxy.go
@@ -438,7 +438,8 @@ var clickhouseRecoverableStatusCodes = map[int]struct{}{http.StatusServiceUnavai
 func (rp *reverseProxy) completeTransaction(s *scope, statusCode int, userCache *cache.AsyncCache, key *cache.Key,
 	q []byte,
 	failReason string) {
-	if statusCode < 300 {
+	// complete successful transactions or those with empty fail reason
+	if statusCode < 300 || failReason == "" {
 		if err := userCache.Complete(key); err != nil {
 			log.Errorf("%s: %s; query: %q", s, err, q)
 		}

--- a/proxy.go
+++ b/proxy.go
@@ -117,7 +117,26 @@ func (rp *reverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if s.user.cache == nil || s.user.cache.Cache == nil {
 		rp.proxyRequest(s, srw, srw, req)
 	} else {
-		rp.serveFromCache(s, srw, req, origParams)
+		noCache := origParams.Get("no_cache")
+		if noCache == "1" || noCache == "true" {
+			// The response caching is disabled.
+			rp.proxyRequest(s, srw, srw, req)
+		} else {
+			q, err := getFullQuery(req)
+			if err != nil {
+				err = fmt.Errorf("%s: cannot read query: %w", s, err)
+				respondWith(srw, err, http.StatusBadRequest)
+				return
+			}
+
+			if !canCacheQuery(q) {
+				// The query cannot be cached, so just proxy it.
+				rp.proxyRequest(s, srw, srw, req)
+			} else {
+				rp.serveFromCache(s, srw, req, origParams, q)
+			}
+
+		}
 	}
 
 	// It is safe calling getQuerySnippet here, since the request
@@ -233,43 +252,9 @@ func (rp *reverseProxy) proxyRequest(s *scope, rw http.ResponseWriter, srw *stat
 	}
 }
 
-func (rp *reverseProxy) serveFromCache(s *scope, srw *statResponseWriter, req *http.Request, origParams url.Values) {
-	noCache := origParams.Get("no_cache")
-	if noCache == "1" || noCache == "true" {
-		// The response caching is disabled.
-		rp.proxyRequest(s, srw, srw, req)
-		return
-	}
-
-	q, err := getFullQuery(req)
-	if err != nil {
-		err = fmt.Errorf("%s: cannot read query: %w", s, err)
-		respondWith(srw, err, http.StatusBadRequest)
-		return
-	}
-	if !canCacheQuery(q) {
-		// The query cannot be cached, so just proxy it.
-		rp.proxyRequest(s, srw, srw, req)
-		return
-	}
-
-	// Do not store `replica` and `cluster_node` in labels, since they have
-	// no sense for cache metrics.
-	labels := prometheus.Labels{
-		"cache":        s.user.cache.Name(),
-		"user":         s.labels["user"],
-		"cluster":      s.labels["cluster"],
-		"cluster_user": s.labels["cluster_user"],
-	}
-
-	var userParamsHash uint32
-	if s.user.params != nil {
-		userParamsHash = s.user.params.key
-	}
-
-	queryParamsHash := calcQueryParamsHash(origParams)
-
-	key := cache.NewKey(skipLeadingComments(q), origParams, sortHeader(req.Header.Get("Accept-Encoding")), userParamsHash, queryParamsHash)
+func (rp *reverseProxy) serveFromCache(s *scope, srw *statResponseWriter, req *http.Request, origParams url.Values, q []byte) {
+	labels := makeCacheLabels(s)
+	key := newCacheKey(s, origParams, q, req)
 
 	startTime := time.Now()
 	userCache := s.user.cache
@@ -279,8 +264,7 @@ func (rp *reverseProxy) serveFromCache(s *scope, srw *statResponseWriter, req *h
 		// The response has been successfully served from cache.
 		defer cachedData.Data.Close()
 		cacheHit.With(labels).Inc()
-		since := time.Since(startTime).Seconds()
-		cachedResponseDuration.With(labels).Observe(since)
+		cachedResponseDuration.With(labels).Observe(time.Since(startTime).Seconds())
 		log.Debugf("%s: cache hit", s)
 		_ = RespondWithData(srw, cachedData.Data, cachedData.ContentMetadata, cachedData.Ttl, http.StatusOK)
 		return
@@ -412,6 +396,28 @@ func (rp *reverseProxy) serveFromCache(s *scope, srw *statResponseWriter, req *h
 			return
 		}
 	}
+}
+
+func makeCacheLabels(s *scope) prometheus.Labels {
+	// Do not store `replica` and `cluster_node` in labels, since they have
+	// no sense for cache metrics.
+	return prometheus.Labels{
+		"cache":        s.user.cache.Name(),
+		"user":         s.labels["user"],
+		"cluster":      s.labels["cluster"],
+		"cluster_user": s.labels["cluster_user"],
+	}
+}
+
+func newCacheKey(s *scope, origParams url.Values, q []byte, req *http.Request) *cache.Key {
+	var userParamsHash uint32
+	if s.user.params != nil {
+		userParamsHash = s.user.params.key
+	}
+
+	queryParamsHash := calcQueryParamsHash(origParams)
+
+	return cache.NewKey(skipLeadingComments(q), origParams, sortHeader(req.Header.Get("Accept-Encoding")), userParamsHash, queryParamsHash)
 }
 
 func toString(stream io.Reader) (string, error) {

--- a/proxy.go
+++ b/proxy.go
@@ -135,7 +135,6 @@ func (rp *reverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			} else {
 				rp.serveFromCache(s, srw, req, origParams, q)
 			}
-
 		}
 	}
 


### PR DESCRIPTION
## Description

Fix for the issue #230 

- update TTL to `500 ms` upon finalisation
- complete transactions instead of failing if fail reason is empty

<!--  Please explain the object of this PR and the changes you made.
A reference to a github issue would be appreciated. --> 

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [ ] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Further comments

I took a liberty also to do a small refactor in proxy.go. I moved logic away from `serveFromCache` that decides if query can be served from cache.

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
