### PR TITLE
cache per user

### DIFF
--- a/cache/async_cache.go
+++ b/cache/async_cache.go
@@ -20,7 +20,8 @@ type AsyncCache struct {
 
 	graceTime time.Duration
 
-	MaxPayloadSize config.ByteSize
+	MaxPayloadSize     config.ByteSize
+	SharedWithAllUsers bool
 }
 
 func (c *AsyncCache) Close() error {
@@ -112,5 +113,6 @@ func NewAsyncCache(cfg config.Cache, maxExecutionTime time.Duration) (*AsyncCach
 		TransactionRegistry: transaction,
 		graceTime:           graceTime,
 		MaxPayloadSize:      maxPayloadSize,
+		SharedWithAllUsers:  cfg.SharedWithAllUsers,
 	}, nil
 }

--- a/cache/key.go
+++ b/cache/key.go
@@ -52,10 +52,13 @@ type Key struct {
 
 	// QueryParamsHash must contain hashed value of query params
 	QueryParamsHash uint32
+
+	// UserCredentialHash must contain hashed value of username & password
+	UserCredentialHash uint32
 }
 
 // NewKey construct cache key from provided parameters with default version number
-func NewKey(query []byte, originParams url.Values, acceptEncoding string, userParamsHash uint32, queryParamsHash uint32) *Key {
+func NewKey(query []byte, originParams url.Values, acceptEncoding string, userParamsHash uint32, queryParamsHash uint32, userCredentialHash uint32) *Key {
 	return &Key{
 		Query:                 query,
 		AcceptEncoding:        acceptEncoding,
@@ -70,6 +73,7 @@ func NewKey(query []byte, originParams url.Values, acceptEncoding string, userPa
 		UserParamsHash:        userParamsHash,
 		Version:               Version,
 		QueryParamsHash:       queryParamsHash,
+		UserCredentialHash:    userCredentialHash,
 	}
 }
 
@@ -79,9 +83,9 @@ func (k *Key) filePath(dir string) string {
 
 // String returns string representation of the key.
 func (k *Key) String() string {
-	s := fmt.Sprintf("V%d; Query=%q; AcceptEncoding=%q; DefaultFormat=%q; Database=%q; Compress=%q; EnableHTTPCompression=%q; Namespace=%q; MaxResultRows=%q; Extremes=%q; ResultOverflowMode=%q; UserParams=%d; QueryParams=%d",
+	s := fmt.Sprintf("V%d; Query=%q; AcceptEncoding=%q; DefaultFormat=%q; Database=%q; Compress=%q; EnableHTTPCompression=%q; Namespace=%q; MaxResultRows=%q; Extremes=%q; ResultOverflowMode=%q; UserParams=%d; QueryParams=%d; UserCredentialHash=%d",
 		k.Version, k.Query, k.AcceptEncoding, k.DefaultFormat, k.Database, k.Compress, k.EnableHTTPCompression, k.Namespace,
-		k.MaxResultRows, k.Extremes, k.ResultOverflowMode, k.UserParamsHash, k.QueryParamsHash)
+		k.MaxResultRows, k.Extremes, k.ResultOverflowMode, k.UserParamsHash, k.QueryParamsHash, k.UserCredentialHash)
 	h := sha256.Sum256([]byte(s))
 
 	// The first 16 bytes of the hash should be enough

--- a/cache/key_test.go
+++ b/cache/key_test.go
@@ -15,7 +15,7 @@ func TestKeyString(t *testing.T) {
 				Query:   []byte("SELECT 1 FROM system.numbers LIMIT 10"),
 				Version: 2,
 			},
-			expected: "ef4c039ea06ce6fd95f4ffef551ba029",
+			expected: "f11e8438adeeb325881c9a4da01925b3",
 		},
 		{
 			key: &Key{
@@ -23,7 +23,7 @@ func TestKeyString(t *testing.T) {
 				AcceptEncoding: "gzip",
 				Version:        2,
 			},
-			expected: "cb83c486eea079a87a6e567ba9869111",
+			expected: "045cbb29a40a81c42378569cf0bc4078",
 		},
 		{
 			key: &Key{
@@ -32,7 +32,7 @@ func TestKeyString(t *testing.T) {
 				DefaultFormat:  "JSON",
 				Version:        2,
 			},
-			expected: "89edc4ac678557d80063d1060b712808",
+			expected: "186386850c49c60a49dbf7af89c671c9",
 		},
 		{
 			key: &Key{
@@ -42,7 +42,7 @@ func TestKeyString(t *testing.T) {
 				Database:       "foobar",
 				Version:        2,
 			},
-			expected: "120d73469183ace3a31c941cfcc8dc13",
+			expected: "68f3231d17cad0a3473e63f419e07580",
 		},
 		{
 			key: &Key{
@@ -53,7 +53,7 @@ func TestKeyString(t *testing.T) {
 				Namespace:      "ns123",
 				Version:        2,
 			},
-			expected: "8441149c2cba1503e201aa94cda949f7",
+			expected: "8f5e765e69df7c24a58f13cdf752ad2f",
 		},
 		{
 			key: &Key{
@@ -65,7 +65,7 @@ func TestKeyString(t *testing.T) {
 				Namespace:      "ns123",
 				Version:        2,
 			},
-			expected: "882a1cfc54f86e75a3ee89757bd33672",
+			expected: "93a121f03f438ef7969540c78e943e2c",
 		},
 		{
 			key: &Key{
@@ -73,7 +73,7 @@ func TestKeyString(t *testing.T) {
 				QueryParamsHash: 3825709,
 				Version:         3,
 			},
-			expected: "9d7a76630ca453d120a7349c4b6fa23d",
+			expected: "7edddc7d9db4bc4036dee36893f57cb1",
 		},
 		{
 			key: &Key{
@@ -81,7 +81,16 @@ func TestKeyString(t *testing.T) {
 				QueryParamsHash: 3825710,
 				Version:         3,
 			},
-			expected: "1899cf94d4c5a3dda9575df7d8734e9b",
+			expected: "68ba76fb53a6fa71ba8fe63dd34a2201",
+		},
+		{
+			key: &Key{
+				Query:              []byte("SELECT * FROM {table_name:Identifier} LIMIT 10"),
+				QueryParamsHash:    3825710,
+				Version:            3,
+				UserCredentialHash: 234324,
+			},
+			expected: "c5b58ecb4ff026e62ee846dc63c749d5",
 		},
 	}
 

--- a/config/README.md
+++ b/config/README.md
@@ -82,7 +82,11 @@ grace_time: <duration>
 
 # Maximum total size of request payload for caching. The default value
 # is set to 1 Petabyte.
+# The default value set so high is to allow users who do not use response size limitations virtually unlimited cache.
 max_payload_size: <byte_size>
+
+# Whether a query cached by a user can be used by another user
+shared_with_all_users: <bool> | default = false [optional]
 ```
 
 ### <distributed_cache_config>
@@ -122,6 +126,9 @@ grace_time: <duration>
 # is set to 1 Petabyte.
 # The default value set so high is to allow users who do not use response size limitations virtually unlimited cache.
 max_payload_size: <byte_size>
+
+# Whether a query cached by a user can be used by another user
+shared_with_all_users: <bool> | default = false [optional]
 ```
 
 ### <param_groups_config>

--- a/config/config.go
+++ b/config/config.go
@@ -665,6 +665,9 @@ type Cache struct {
 
 	// Maximum total size of request payload for caching
 	MaxPayloadSize ByteSize `yaml:"max_payload_size,omitempty"`
+
+	// Whether a query cached by a user could be used by another user
+	SharedWithAllUsers bool `yaml:"shared_with_all_users,omitempty"`
 }
 
 type FileSystemCacheConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,9 +21,10 @@ var fullConfig = Config{
 				Dir:     "/path/to/longterm/cachedir",
 				MaxSize: ByteSize(100 << 30),
 			},
-			Expire:         Duration(time.Hour),
-			GraceTime:      Duration(20 * time.Second),
-			MaxPayloadSize: ByteSize(100 << 30),
+			Expire:             Duration(time.Hour),
+			GraceTime:          Duration(20 * time.Second),
+			MaxPayloadSize:     ByteSize(100 << 30),
+			SharedWithAllUsers: false,
 		},
 		{
 			Name: "shortterm",
@@ -32,8 +33,9 @@ var fullConfig = Config{
 				Dir:     "/path/to/shortterm/cachedir",
 				MaxSize: ByteSize(100 << 20),
 			},
-			Expire:         Duration(10 * time.Second),
-			MaxPayloadSize: ByteSize(100 << 20),
+			Expire:             Duration(10 * time.Second),
+			MaxPayloadSize:     ByteSize(100 << 20),
+			SharedWithAllUsers: true,
 		},
 	},
 	HackMePlease: true,
@@ -851,6 +853,7 @@ caches:
     dir: /path/to/shortterm/cachedir
     max_size: 104857600
   max_payload_size: 104857600
+  shared_with_all_users: true
 param_groups:
 - name: cron-job
   params:

--- a/config/testdata/full.yml
+++ b/config/testdata/full.yml
@@ -47,6 +47,7 @@ caches:
       max_size: 100Mb
       dir: "/path/to/shortterm/cachedir"
     max_payload_size: 100Mb
+    shared_with_all_users: true
     expire: 10s
 
 # Optional network lists, might be used as values for `allowed_networks`.

--- a/docs/content/en/configuration/caching.md
+++ b/docs/content/en/configuration/caching.md
@@ -49,3 +49,14 @@ When Clickhouse responds to the firstly arrived query, existing key is updated a
 - if failed, as failed along with the exception message prepended with `[concurrent query failed]`.
 
 Transaction is kept for the duration of 2 * grace_time or 2 * max_execution_time, depending if grace time is specified.
+
+#### Cache shared with all users
+Until version 1.19.0, the cache is shared with all users.
+It means that if:
+- a user X does a query A,
+- then the result is cached,
+- then a user Y does the same query A
+User Y will get the cached response from user X's query.
+
+Since 1.20.0, the cache is specific for each user by default since it's better in terms of security.
+It's possible to use the previous behavior by setting the following property of the cache in the config file `shared_with_all_users = true` 

--- a/main_test.go
+++ b/main_test.go
@@ -675,6 +675,48 @@ func TestServe(t *testing.T) {
 			startHTTP,
 		},
 		{
+			"http share cache for same user with different pwd",
+			"testdata/http.shared.cache.yml",
+			func(t *testing.T) {
+				// because of the wildcarded feature that delegate the authentication to clickouse
+				// we can't afford to return a cached of the same user without reaching clickhouse
+				// if the pwd is not the same than the one used for the cached query
+				cacheDir := "temp-test-data/shared_cache4"
+				checkFilesCount(t, cacheDir, 0)
+				httpGet(t, "http://127.0.0.1:9090?query=SELECT&user=user1_test4&password=toto", http.StatusOK)
+				checkFilesCount(t, cacheDir, 1)
+				httpGet(t, "http://127.0.0.1:9090?query=SELECT&user=user2_test4&password=titi", http.StatusOK)
+				checkFilesCount(t, cacheDir, 1)
+			},
+			startHTTP,
+		},
+		{
+			"http share cache for different user",
+			"testdata/http.shared.cache.yml",
+			func(t *testing.T) {
+				cacheDir := "temp-test-data/shared_cache5"
+				checkFilesCount(t, cacheDir, 0)
+				httpGet(t, "http://127.0.0.1:9090?query=SELECT&user=user1_test5", http.StatusOK)
+				checkFilesCount(t, cacheDir, 1)
+				httpGet(t, "http://127.0.0.1:9090?query=SELECT&user=user2_test5", http.StatusOK)
+				checkFilesCount(t, cacheDir, 1)
+			},
+			startHTTP,
+		},
+		{
+			"http not share cache for different user using wildcarded feature",
+			"testdata/http.shared.cache.yml",
+			func(t *testing.T) {
+				cacheDir := "temp-test-data/shared_cache6"
+				checkFilesCount(t, cacheDir, 0)
+				httpGet(t, "http://127.0.0.1:9090?query=SELECT&user=user1_test6", http.StatusOK)
+				checkFilesCount(t, cacheDir, 1)
+				httpGet(t, "http://127.0.0.1:9090?query=SELECT&user=user2_test6", http.StatusOK)
+				checkFilesCount(t, cacheDir, 2)
+			},
+			startHTTP,
+		},
+		{
 			"http cached gzipped deadline",
 			"testdata/http.cache.deadline.yml",
 			func(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -95,10 +95,12 @@ func TestServe(t *testing.T) {
 				checkResponse(t, resp.Body, expectedOkResp)
 
 				// check cached response
+				credHash, _ := calcCredentialHash("default", "qwerty")
 				key := &cache.Key{
-					Query:          []byte(q),
-					AcceptEncoding: "gzip",
-					Version:        cache.Version,
+					Query:              []byte(q),
+					AcceptEncoding:     "gzip",
+					Version:            cache.Version,
+					UserCredentialHash: credHash,
 				}
 				path := fmt.Sprintf("%s/cache/%s", testDir, key.String())
 				if _, err := os.Stat(path); err != nil {
@@ -173,10 +175,12 @@ func TestServe(t *testing.T) {
 
 				checkResponse(t, resp.Body, expectedOkResp)
 
+				credHash, _ := calcCredentialHash("default", "qwerty")
 				key := &cache.Key{
-					Query:          []byte(q),
-					AcceptEncoding: "gzip",
-					Version:        cache.Version,
+					Query:              []byte(q),
+					AcceptEncoding:     "gzip",
+					Version:            cache.Version,
+					UserCredentialHash: credHash,
 				}
 
 				rw := httptest.NewRecorder()
@@ -219,11 +223,14 @@ func TestServe(t *testing.T) {
 				resp.Body.Close()
 
 				// check cached response
+				credHash, _ := calcCredentialHash("default", "qwerty")
 				key := &cache.Key{
-					Query:          []byte(expectedQuery),
-					AcceptEncoding: "gzip",
-					Version:        cache.Version,
+					Query:              []byte(expectedQuery),
+					AcceptEncoding:     "gzip",
+					Version:            cache.Version,
+					UserCredentialHash: credHash,
 				}
+
 				path := fmt.Sprintf("%s/cache/%s", testDir, key.String())
 				if _, err := os.Stat(path); err != nil {
 					t.Fatalf("err while getting file %q info: %s", path, err)
@@ -265,10 +272,12 @@ func TestServe(t *testing.T) {
 				resp.Body.Close()
 
 				// check cached response
+				credHash, _ := calcCredentialHash("default", "qwerty")
 				key := &cache.Key{
-					Query:          []byte(q),
-					AcceptEncoding: "gzip",
-					Version:        cache.Version,
+					Query:              []byte(q),
+					AcceptEncoding:     "gzip",
+					Version:            cache.Version,
+					UserCredentialHash: credHash,
 				}
 				path := fmt.Sprintf("%s/cache/%s", testDir, key.String())
 				if _, err := os.Stat(path); !os.IsNotExist(err) {
@@ -448,10 +457,12 @@ func TestServe(t *testing.T) {
 				}
 
 				// check cached response
+				credHash, _ := calcCredentialHash("default", "")
 				key := &cache.Key{
-					Query:          []byte(q),
-					AcceptEncoding: "gzip",
-					Version:        cache.Version,
+					Query:              []byte(q),
+					AcceptEncoding:     "gzip",
+					Version:            cache.Version,
+					UserCredentialHash: credHash,
 				}
 
 				duration := redisClient.TTL(key.String())
@@ -617,20 +628,49 @@ func TestServe(t *testing.T) {
 			startHTTP,
 		},
 		{
-			"http shared cache",
+			"http shared cache for them user",
 			"testdata/http.shared.cache.yml",
 			func(t *testing.T) {
 				// actually we can check that cache-file is shared via metrics
 				// but it needs additional library for doing this
 				// so it would be just files amount check
-				cacheDir := "temp-test-data/shared_cache"
+				cacheDir := "temp-test-data/shared_cache1"
 				checkFilesCount(t, cacheDir, 0)
-				httpGet(t, "http://127.0.0.1:9090?query=SELECT&user=user1", http.StatusOK)
+				httpGet(t, "http://127.0.0.1:9090?query=SELECT&user=user1_test1", http.StatusOK)
 				checkFilesCount(t, cacheDir, 1)
-				httpGet(t, "http://127.0.0.1:9090?query=SELECT&user=user2", http.StatusOK)
+				httpGet(t, "http://127.0.0.1:9090?query=SELECT&user=user1_test1", http.StatusOK)
 				// request from different user expected to be served with already cached,
 				// so count of files should be the same
 				checkFilesCount(t, cacheDir, 1)
+			},
+			startHTTP,
+		},
+		{
+			"http not share cache for same user with different pwd",
+			"testdata/http.shared.cache.yml",
+			func(t *testing.T) {
+				// because of the wildcarded feature that delegate the authentication to clickouse
+				// we can't afford to return a cached of the same user without reaching clickhouse
+				// if the pwd is not the same than the one used for the cached query
+				cacheDir := "temp-test-data/shared_cache2"
+				checkFilesCount(t, cacheDir, 0)
+				httpGet(t, "http://127.0.0.1:9090?query=SELECT&user=user1_test2&password=toto", http.StatusOK)
+				checkFilesCount(t, cacheDir, 1)
+				httpGet(t, "http://127.0.0.1:9090?query=SELECT&user=user2_test2&password=titi", http.StatusOK)
+				checkFilesCount(t, cacheDir, 2)
+			},
+			startHTTP,
+		},
+		{
+			"http not share cache for different user",
+			"testdata/http.shared.cache.yml",
+			func(t *testing.T) {
+				cacheDir := "temp-test-data/shared_cache3"
+				checkFilesCount(t, cacheDir, 0)
+				httpGet(t, "http://127.0.0.1:9090?query=SELECT&user=user1_test3", http.StatusOK)
+				checkFilesCount(t, cacheDir, 1)
+				httpGet(t, "http://127.0.0.1:9090?query=SELECT&user=user2_test3", http.StatusOK)
+				checkFilesCount(t, cacheDir, 2)
 			},
 			startHTTP,
 		},
@@ -795,7 +835,7 @@ func checkFilesCount(t *testing.T, dir string, expectedLen int) {
 		t.Fatalf("error while reading dir %q: %s", dir, err)
 	}
 	if expectedLen != len(files) {
-		t.Fatalf("expected %d files in cache dir; got: %d", expectedLen, len(files))
+		t.Fatalf("expected %d files in cache dir %s; got: %d", expectedLen, dir, len(files))
 	}
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -489,7 +489,11 @@ func newCacheKey(s *scope, origParams url.Values, q []byte, req *http.Request) *
 	}
 
 	queryParamsHash := calcQueryParamsHash(origParams)
-	credHash, err := calcCredentialHash(s.user.name, s.user.password)
+	credHash, err := uint32(0), error(nil)
+
+	if !s.user.cache.SharedWithAllUsers {
+		credHash, err = calcCredentialHash(s.clusterUser.name, s.clusterUser.password)
+	}
 	if err != nil {
 		log.Errorf("fail to calc hash on credentials for user %s", s.user.name)
 		credHash = 0

--- a/proxy.go
+++ b/proxy.go
@@ -489,6 +489,11 @@ func newCacheKey(s *scope, origParams url.Values, q []byte, req *http.Request) *
 	}
 
 	queryParamsHash := calcQueryParamsHash(origParams)
+	credHash, err := calcCredentialHash(s.user.name, s.user.password)
+	if err != nil {
+		log.Errorf("fail to calc hash on credentials for user %s", s.user.name)
+		credHash = 0
+	}
 
 	return cache.NewKey(
 		skipLeadingComments(q),
@@ -496,6 +501,7 @@ func newCacheKey(s *scope, origParams url.Values, q []byte, req *http.Request) *
 		sortHeader(req.Header.Get("Accept-Encoding")),
 		userParamsHash,
 		queryParamsHash,
+		credHash,
 	)
 }
 

--- a/testdata/http.cache.max-payload-size-not-reached.yml
+++ b/testdata/http.cache.max-payload-size-not-reached.yml
@@ -24,3 +24,6 @@ users:
 clusters:
   - name: "default"
     nodes: ["127.0.0.1:8124"]
+    users:
+    - name: "default"
+      password: "qwerty"

--- a/testdata/http.cache.yml
+++ b/testdata/http.cache.yml
@@ -13,7 +13,9 @@ users:
 clusters:
   - name: "default"
     nodes: ["127.0.0.1:8124"]
-
+    users:
+    - name: "default"
+      password: "qwerty"
 
 caches:
   - name: "shortterm"

--- a/testdata/http.shared.cache.yml
+++ b/testdata/http.shared.cache.yml
@@ -1,8 +1,20 @@
 caches:
-  - name: "shared_cache"
+  - name: "shared_cache1"
     mode: "file_system"
     file_system:
-      dir: "temp-test-data/shared_cache"
+      dir: "temp-test-data/shared_cache1"
+      max_size: "10M"
+    expire: "1m"
+  - name: "shared_cache2"
+    mode: "file_system"
+    file_system:
+      dir: "temp-test-data/shared_cache2"
+      max_size: "10M"
+    expire: "1m"
+  - name: "shared_cache3"
+    mode: "file_system"
+    file_system:
+      dir: "temp-test-data/shared_cache3"
       max_size: "10M"
     expire: "1m"
 
@@ -12,12 +24,26 @@ server:
       allowed_networks: ["127.0.0.1/24"]
 
 users:
-  - name: "user1"
-    cache: "shared_cache"
+  - name: "user1_test1"
+    cache: "shared_cache1"
     to_cluster: "default"
     to_user: "default"
-  - name: "user2"
-    cache: "shared_cache"
+  - name: "user1_test2"
+    password: "toto"
+    cache: "shared_cache2"
+    to_cluster: "default"
+    to_user: "default"
+  - name: "user2_test2"
+    password: "titi"
+    cache: "shared_cache2"
+    to_cluster: "default"
+    to_user: "default"
+  - name: "user1_test3"
+    cache: "shared_cache3"
+    to_cluster: "default"
+    to_user: "default"
+  - name: "user2_test3"
+    cache: "shared_cache3"
     to_cluster: "default"
     to_user: "default"
 

--- a/testdata/http.shared.cache.yml
+++ b/testdata/http.shared.cache.yml
@@ -5,18 +5,46 @@ caches:
       dir: "temp-test-data/shared_cache1"
       max_size: "10M"
     expire: "1m"
+
   - name: "shared_cache2"
     mode: "file_system"
     file_system:
       dir: "temp-test-data/shared_cache2"
       max_size: "10M"
     expire: "1m"
+
   - name: "shared_cache3"
     mode: "file_system"
     file_system:
       dir: "temp-test-data/shared_cache3"
       max_size: "10M"
     expire: "1m"
+
+  - name: "shared_cache4"
+    mode: "file_system"
+    file_system:
+      dir: "temp-test-data/shared_cache4"
+      max_size: "10M"
+    expire: "1m"
+    shared_with_all_users: true
+    max_payload_size: "50M"
+
+  - name: "shared_cache5"
+    mode: "file_system"
+    file_system:
+      dir: "temp-test-data/shared_cache5"
+      max_size: "10M"
+    expire: "1m"
+    shared_with_all_users: true
+    max_payload_size: "150M"
+
+  - name: "shared_cache6"
+    mode: "file_system"
+    file_system:
+      dir: "temp-test-data/shared_cache6"
+      max_size: "10M"
+    expire: "1m"
+    max_payload_size: "5M"
 
 server:
   http:
@@ -27,26 +55,73 @@ users:
   - name: "user1_test1"
     cache: "shared_cache1"
     to_cluster: "default"
-    to_user: "default"
+    to_user: "user1_test1"
+
   - name: "user1_test2"
     password: "toto"
     cache: "shared_cache2"
     to_cluster: "default"
-    to_user: "default"
+    to_user: "user1_test2"
   - name: "user2_test2"
     password: "titi"
     cache: "shared_cache2"
     to_cluster: "default"
-    to_user: "default"
+    to_user: "user2_test2"
+
   - name: "user1_test3"
     cache: "shared_cache3"
     to_cluster: "default"
-    to_user: "default"
+    to_user: "user1_test3"
   - name: "user2_test3"
     cache: "shared_cache3"
     to_cluster: "default"
-    to_user: "default"
+    to_user: "user2_test3"
 
+  - name: "user1_test4"
+    password: "toto"
+    cache: "shared_cache4"
+    to_cluster: "default"
+    to_user: "user1_test4"
+  - name: "user2_test4"
+    password: "titi"
+    cache: "shared_cache4"
+    to_cluster: "default"
+    to_user: "user2_test4"
+
+  - name: "user1_test5"
+    cache: "shared_cache5"
+    to_cluster: "default"
+    to_user: "user1_test5"
+  - name: "user2_test5"
+    cache: "shared_cache5"
+    to_cluster: "default"
+    to_user: "user2_test5"
+
+  - name: "*_test6"
+    cache: "shared_cache6"
+    to_cluster: "default"
+    to_user: "default"
+    is_wildcarded: true
 clusters:
   - name: "default"
     nodes: ["127.0.0.1:8124"]
+    users:
+    - name: "default"
+    - name: "user1_test1"
+      password: "password"
+    - name: "user1_test2"
+      password: "password"
+    - name: "user2_test2"
+      password: "password"
+    - name: "user1_test3"
+      password: "password"
+    - name: "user2_test3"
+      password: "password"
+    - name: "user1_test4"
+      password: "toto"
+    - name: "user2_test4"
+      password: "titi"
+    - name: "user1_test5"
+      password: "password"
+    - name: "user2_test5"
+      password: "password"

--- a/testdata/https.cache.max-payload-size-not-reached.yml
+++ b/testdata/https.cache.max-payload-size-not-reached.yml
@@ -25,3 +25,6 @@ users:
 clusters:
   - name: "default"
     nodes: ["127.0.0.1:8124"]
+    users:
+    - name: "default"
+      password: "qwerty"

--- a/testdata/https.cache.yml
+++ b/testdata/https.cache.yml
@@ -23,3 +23,6 @@ users:
 clusters:
   - name: "default"
     nodes: ["127.0.0.1:8124"]
+    users:
+    - name: "default"
+      password: "qwerty"

--- a/utils.go
+++ b/utils.go
@@ -289,3 +289,8 @@ func calcMapHash(m map[string]string) (uint32, error) {
 	}
 	return h.Sum32(), nil
 }
+func calcCredentialHash(user string, pwd string) (uint32, error) {
+	h := fnv.New32a()
+	_, err := h.Write([]byte(user + pwd))
+	return h.Sum32(), err
+}


### PR DESCRIPTION
## Description

cf https://github.com/ContentSquare/chproxy/issues/256, having the same cache for all users could be a security leak with wildcarded user (and is a smaller leak without wildcarded user).
The aim is to have a cache per user by default and let the admin choses whether or not the cache should be shared btw all users

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [x] Linter passes correctly
- [x] Add tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No
after the upgrade, all the queries put in cache (redis or filesystem) put by a previous version of chproxy will not be seen by the new version. Moreover, by default the queries won't be shared per user unless explicitly asked in the conf.
## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
