### PR TITLE
Add proxy.skip_tls_verify config option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -324,6 +324,10 @@ type Proxy struct {
 	// will be ignored.
 	Header string `yaml:"header,omitempty"`
 
+	// SkipTLSVerify: if true, ignore TLS certificate validation errors when
+	// connecting to backends.  (Default is false.)
+	SkipTLSVerify bool `yaml:"skip_tls_verify"`
+
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -355,6 +355,11 @@ func TestBadConfig(t *testing.T) {
 			"`cluster.scheme` must be `http` or `https`, got \"tcp\" instead for \"second cluster\"",
 		},
 		{
+			"wrong tls verify",
+			"testdata/bad.wrong_tls_verify.yml",
+			"yaml: unmarshal errors:\n  line 5: cannot unmarshal !!str `true` into bool",
+		},
+		{
 			"empty https",
 			"testdata/bad.empty_https.yml",
 			"configuration `https` is missing. Must be specified `https.cache_dir` for autocert OR `https.key_file` and `https.cert_file` for already existing certs",
@@ -735,6 +740,7 @@ func TestConfigString(t *testing.T) {
   proxy:
     enable: true
     header: CF-Connecting-IP
+    skip_tls_verify: false
 clusters:
 - name: first cluster
   scheme: http

--- a/config/testdata/bad.wrong_tls_verify.yml
+++ b/config/testdata/bad.wrong_tls_verify.yml
@@ -1,0 +1,15 @@
+server:
+  http:
+    listen_addr: ":8080"
+  proxy:
+    skip_tls_verify: "true"
+
+users:
+  - name: "default"
+    to_cluster: "second cluster"
+    to_user: "default"
+
+clusters:
+  - name: "second cluster"
+    scheme: "https"
+    nodes: ["127.0.1.1:8123"]

--- a/docs/content/en/configuration/default.md
+++ b/docs/content/en/configuration/default.md
@@ -166,6 +166,8 @@ server:
   proxy:
     enable: true
     header: CF-Connecting-IP
+    # Set this to true to disable TLS validation of backend proxies using https
+    skip_tls_verify: false
 
 # Configs for input users.
 users:

--- a/docs/content/en/configuration/proxy.md
+++ b/docs/content/en/configuration/proxy.md
@@ -30,3 +30,13 @@ server:
 ```
 
 `Chproxy` assumes the header contains the remote address and doesn't apply any parsing logic to extract the remote address from the header. 
+
+Additionally, TLS verification of backend servers using the `https` scheme can be disabled in this section:
+
+```yml
+server:
+  proxy:
+    skip_tls_verify: true
+```
+
+This is obviously a potential security risk! This is intented primarily for testing/QA scenarios where the remote server may have a self-signed certificate.

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -11,23 +11,25 @@ import (
 )
 
 type heartBeat struct {
-	interval time.Duration
-	timeout  time.Duration
-	request  string
-	response string
-	user     string
-	password string
+	interval   time.Duration
+	timeout    time.Duration
+	request    string
+	response   string
+	user       string
+	password   string
+	httpClient *http.Client
 }
 
 // User credentials are not needed
 const pingStr string = "/ping"
 
-func newHeartBeat(c config.HeartBeat, firstClusterUser config.ClusterUser) *heartBeat {
+func newHeartBeat(c config.HeartBeat, firstClusterUser config.ClusterUser, httpClient *http.Client) *heartBeat {
 	newHB := &heartBeat{
-		interval: time.Duration(c.Interval),
-		timeout:  time.Duration(c.Timeout),
-		request:  c.Request,
-		response: c.Response,
+		interval:   time.Duration(c.Interval),
+		timeout:    time.Duration(c.Timeout),
+		request:    c.Request,
+		response:   c.Response,
+		httpClient: httpClient,
 	}
 	if c.Request != pingStr {
 		if len(c.User) > 0 {
@@ -54,7 +56,7 @@ func (hb *heartBeat) isHealthy(addr string) error {
 	req = req.WithContext(ctx)
 
 	startTime := time.Now()
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := hb.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("cannot send request in %s: %w", time.Since(startTime), err)
 	}

--- a/heartbeat_test.go
+++ b/heartbeat_test.go
@@ -85,13 +85,13 @@ var (
 )
 
 func TestNewHeartBeat(t *testing.T) {
-	c, err := newCluster(clusterCfg)
+	c, err := newCluster(clusterCfg, false)
 	if err != nil {
 		t.Fatalf("error while initialize claster: %s", err)
 	}
 	testCompareNum(t, "cluster.heartbeat.interval", int64(c.heartBeat.interval/time.Microsecond), int64(time.Duration(5*time.Second)/time.Microsecond))
 
-	hb := newHeartBeat(heartBeatFullCfg, clusterCfg.ClusterUsers[0])
+	hb := newHeartBeat(heartBeatFullCfg, clusterCfg.ClusterUsers[0], &http.Client{})
 	testCompareNum(t, "heartbeat.interval", int64(hb.interval/time.Microsecond), int64(time.Duration(20*time.Second)/time.Microsecond))
 	testCompareNum(t, "heartbeat.timeout", int64(hb.timeout/time.Microsecond), int64(time.Duration(30*time.Second)/time.Microsecond))
 	testCompareStr(t, "heartbeat.request", hb.request, "/?query=SELECT%201")
@@ -105,14 +105,14 @@ func TestNewHeartBeat(t *testing.T) {
 		t.Fatalf("query request error `%q`", check)
 	}
 
-	hbWrong := newHeartBeat(heartBeatWrongResponseCfg, clusterCfg.ClusterUsers[0])
+	hbWrong := newHeartBeat(heartBeatWrongResponseCfg, clusterCfg.ClusterUsers[0], &http.Client{})
 	check := hbWrong.isHealthy(fakeHBServer.URL)
 	if check == nil {
 		t.Fatalf("heartbeat error expected")
 	}
 	testCompareStr(t, "heartbeat error", check.Error(), "unexpected response: wrong\n")
 
-	hbNameWrong := newHeartBeat(heartBeatWrongNamedCfg, clusterCfg.ClusterUsers[0])
+	hbNameWrong := newHeartBeat(heartBeatWrongNamedCfg, clusterCfg.ClusterUsers[0], &http.Client{})
 	testCompareStr(t, "heartbeat.user", hbNameWrong.user, "hbuser")
 	testCompareStr(t, "heartbeat.password", hbNameWrong.password, "hbpassword")
 }

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ var (
 )
 
 var (
-	proxy = newReverseProxy()
+	proxy *reverseProxy
 
 	// networks allow lists
 	allowedNetworksHTTP    atomic.Value
@@ -229,6 +229,10 @@ func serveHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	switch r.URL.Path {
+	case "/health":
+		rw.WriteHeader(http.StatusOK)
+		rw.Write([]byte(http.StatusText(http.StatusOK)))
+		return
 	case "/favicon.ico":
 	case "/metrics":
 		an := allowedNetworksMetrics.Load().(*config.Networks)
@@ -280,6 +284,9 @@ func loadConfig() (*config.Config, error) {
 }
 
 func applyConfig(cfg *config.Config) error {
+	if proxy == nil {
+		proxy = newReverseProxy(cfg.Server.Proxy.SkipTLSVerify)
+	}
 	if err := proxy.applyConfig(cfg); err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -280,7 +280,6 @@ func loadConfig() (*config.Config, error) {
 }
 
 func applyConfig(cfg *config.Config) error {
-
 	// if the proxy has not been initialized, or if the value for
 	// cfg.server.proxy.skipTLSVerify has changed, initialize it
 	if proxy == nil || cfg.Server.Proxy.SkipTLSVerify != proxy.skipTLSVerify {

--- a/main_test.go
+++ b/main_test.go
@@ -1059,7 +1059,7 @@ func TestReloadConfig(t *testing.T) {
 		t.Fatal("error expected; got nil")
 	}
 
-	assert.Equal(t, proxy.skipTlsVerify, false)
+	assert.Equal(t, proxy.skipTLSVerify, false)
 }
 
 func TestReloadConfigProxyEnabled(t *testing.T) {
@@ -1067,7 +1067,7 @@ func TestReloadConfigProxyEnabled(t *testing.T) {
 	if err := reloadConfig(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	assert.Equal(t, false, proxy.skipTlsVerify)
+	assert.Equal(t, false, proxy.skipTLSVerify)
 }
 
 func TestReloadConfigSkipBackendTLSVerify(t *testing.T) {
@@ -1075,7 +1075,7 @@ func TestReloadConfigSkipBackendTLSVerify(t *testing.T) {
 	if err := reloadConfig(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	assert.Equal(t, true, proxy.skipTlsVerify)
+	assert.Equal(t, true, proxy.skipTLSVerify)
 }
 
 func checkErr(t *testing.T, err error) {

--- a/main_test.go
+++ b/main_test.go
@@ -1058,6 +1058,24 @@ func TestReloadConfig(t *testing.T) {
 	if err := reloadConfig(); err == nil {
 		t.Fatal("error expected; got nil")
 	}
+
+	assert.Equal(t, proxy.skipTlsVerify, false)
+}
+
+func TestReloadConfigProxyEnabled(t *testing.T) {
+	*configFile = "testdata/https.proxy-enabled.yml"
+	if err := reloadConfig(); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	assert.Equal(t, false, proxy.skipTlsVerify)
+}
+
+func TestReloadConfigSkipBackendTLSVerify(t *testing.T) {
+	*configFile = "testdata/https.proxy-enabled-backend-tls-disabled.yml"
+	if err := reloadConfig(); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	assert.Equal(t, true, proxy.skipTlsVerify)
 }
 
 func checkErr(t *testing.T, err error) {

--- a/proxy.go
+++ b/proxy.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -47,11 +48,15 @@ type reverseProxy struct {
 	hasWildcarded bool
 }
 
-func newReverseProxy() *reverseProxy {
+func newReverseProxy(skipTLSVerify bool) *reverseProxy {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if skipTLSVerify {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
 	return &reverseProxy{
 		rp: &httputil.ReverseProxy{
-			Director: func(*http.Request) {},
-
+			Director:  func(*http.Request) {},
+			Transport: transport,
 			// Suppress error logging in ReverseProxy, since all the errors
 			// are handled and logged in the code below.
 			ErrorLog: log.NilLogger,

--- a/proxy.go
+++ b/proxy.go
@@ -571,7 +571,7 @@ func (rp *reverseProxy) applyConfig(cfg *config.Config) error {
 	rp.configLock.Lock()
 	defer rp.configLock.Unlock()
 
-	clusters, err := newClusters(cfg.Clusters)
+	clusters, err := newClusters(cfg.Clusters, cfg.Server.Proxy.SkipTLSVerify)
 	if err != nil {
 		return err
 	}
@@ -825,6 +825,6 @@ func (rp *reverseProxy) getScope(req *http.Request) (*scope, int, error) {
 		return nil, http.StatusForbidden, fmt.Errorf("cluster user %q is not allowed to access", cu.name)
 	}
 
-	s := newScope(req, u, c, cu, sessionId, sessionTimeout)
+	s := newScope(req, u, c, cu, sessionId, sessionTimeout, rp.skipTLSVerify)
 	return s, 0, nil
 }

--- a/proxy.go
+++ b/proxy.go
@@ -46,7 +46,7 @@ type reverseProxy struct {
 	clusters      map[string]*cluster
 	caches        map[string]*cache.AsyncCache
 	hasWildcarded bool
-	skipTlsVerify bool
+	skipTLSVerify bool
 }
 
 func newReverseProxy(skipTLSVerify bool) *reverseProxy {
@@ -64,7 +64,7 @@ func newReverseProxy(skipTLSVerify bool) *reverseProxy {
 		},
 		reloadSignal:  make(chan struct{}),
 		reloadWG:      sync.WaitGroup{},
-		skipTlsVerify: skipTLSVerify,
+		skipTLSVerify: skipTLSVerify,
 	}
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -46,6 +46,7 @@ type reverseProxy struct {
 	clusters      map[string]*cluster
 	caches        map[string]*cache.AsyncCache
 	hasWildcarded bool
+	skipTlsVerify bool
 }
 
 func newReverseProxy(skipTLSVerify bool) *reverseProxy {
@@ -61,8 +62,9 @@ func newReverseProxy(skipTLSVerify bool) *reverseProxy {
 			// are handled and logged in the code below.
 			ErrorLog: log.NilLogger,
 		},
-		reloadSignal: make(chan struct{}),
-		reloadWG:     sync.WaitGroup{},
+		reloadSignal:  make(chan struct{}),
+		reloadWG:      sync.WaitGroup{},
+		skipTlsVerify: skipTLSVerify,
 	}
 }
 

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -68,7 +68,7 @@ var goodCfg = &config.Config{
 }
 
 func newConfiguredProxy(cfg *config.Config) (*reverseProxy, error) {
-	p := newReverseProxy()
+	p := newReverseProxy(false)
 	if err := p.applyConfig(cfg); err != nil {
 		return p, fmt.Errorf("error while loading config: %s", err)
 	}
@@ -82,7 +82,7 @@ func init() {
 }
 
 func TestNewReverseProxy(t *testing.T) {
-	proxy := newReverseProxy()
+	proxy := newReverseProxy(false)
 	if err := proxy.applyConfig(goodCfg); err != nil {
 		t.Fatalf("error while loading config: %s", err)
 	}

--- a/testdata/https.proxy-enabled-backend-tls-disabled.yml
+++ b/testdata/https.proxy-enabled-backend-tls-disabled.yml
@@ -1,0 +1,20 @@
+log_debug: true
+server:
+  https:
+      listen_addr: ":8443"
+      cert_file: "testdata/example.com.cert"
+      key_file: "testdata/example.com.key"
+      allowed_networks: ["10.0.0.0/24"]
+  proxy:
+    enable: true
+    skip_tls_verify: true
+
+users:
+  - name: "default"
+    password: "qwerty"
+    to_cluster: "default"
+    to_user: "default"
+
+clusters:
+  - name: "default"
+    nodes: ["127.0.0.1:8124"]


### PR DESCRIPTION
## Description

If `server.proxy.skip_tls_verify` is set to true, create a custom transport for the reverse proxy that disables TLS verification; this would be used e.g. for clusters that have self-signed certificates for testing.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [X] Linter passes correctly
- [X] Add tests which fail without the change (if possible)
- [X] All tests passing
- [X] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No
