### PR TITLE
chore: Reenable gosec linter and upgrade TLS version.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,7 @@ linters:
     - unused
     - varcheck
     - whitespace
+    - gosec
   disable:
     # Should be readded in the future with a dedicated PR to do the fix
     - cyclop
@@ -51,7 +52,6 @@ linters:
     - funlen
     - gocognit
     - gofumpt
-    - gosec
     - govet
     - ifshort
     - ineffassign

--- a/cache/filesystem_cache.go
+++ b/cache/filesystem_cache.go
@@ -273,6 +273,7 @@ func (f *fileSystemCache) clean() {
 	//
 	// Seed the generator with the current time in order to randomize
 	// set of files to be removed below.
+	// nolint:gosec // not security sensitve, only used internally.
 	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	for totalSize > f.maxSize && loopsCount < 3 {

--- a/cache/redis_cache.go
+++ b/cache/redis_cache.go
@@ -251,6 +251,7 @@ func (r *redisCache) Put(reader io.Reader, contentMetadata ContentMetadata, key 
 	stringKey := key.String()
 	// in order to make the streaming operation atomic, chproxy streams into a temporary key (only known by the current goroutine)
 	// then it switches the full result to the "real" stringKey available for other goroutines
+	// nolint:gosec // not security sensitve, only used internally.
 	random := strconv.Itoa(rand.Int())
 	stringKeyTmp := stringKey + random + "_tmp"
 

--- a/main.go
+++ b/main.go
@@ -171,6 +171,7 @@ func serve(cfg config.HTTP) {
 func newTLSConfig(cfg config.HTTPS) *tls.Config {
 	tlsCfg := tls.Config{
 		PreferServerCipherSuites: true,
+		MinVersion:               tls.VersionTLS12,
 		CurvePreferences: []tls.CurveID{
 			tls.CurveP256,
 			tls.X25519,
@@ -193,13 +194,13 @@ func newTLSConfig(cfg config.HTTPS) *tls.Config {
 }
 
 func newServer(ln net.Listener, h http.Handler, cfg config.TimeoutCfg) *http.Server {
+	// nolint:gosec // We already configured ReadTimeout, so no need to set ReadHeaderTimeout as well.
 	return &http.Server{
 		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
 		Handler:      h,
 		ReadTimeout:  time.Duration(cfg.ReadTimeout),
 		WriteTimeout: time.Duration(cfg.WriteTimeout),
 		IdleTimeout:  time.Duration(cfg.IdleTimeout),
-
 		// Suppress error logging from the server, since chproxy
 		// must handle all these errors in the code.
 		ErrorLog: log.NilLogger,


### PR DESCRIPTION
## Description

<!--  Please explain the object of this PR and the changes you made.
A reference to a github issue would be appreciated. --> 

Re-add gosec to the list of golangci linters

We use math/rand in a place where it won't affect security, so disabling the linter for those lines is fine. TLS version is upgraded as most clients should use TLS 1.2 by default anyway. A lot of applications/vendors have already deprecated TLS 1.0.

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Security Related Change


### Checklist

- [ ] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No


BREAKING: no longer support TLS 1.0. Most clients should already default to TLS 1.2. Multiple vendors have already end-of-lifed TLS 1.0.

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
