### PR TITLE
chore: Reenable forcetypeassert

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,11 +44,11 @@ linters:
     - varcheck
     - whitespace
     - gosec
+    - forcetypeassert
   disable:
     # Should be readded in the future with a dedicated PR to do the fix
     - cyclop
     - exhaustive
-    - forcetypeassert
     - funlen
     - gocognit
     - gofumpt

--- a/cache/filesystem_cache_test.go
+++ b/cache/filesystem_cache_test.go
@@ -254,6 +254,10 @@ func (trw *testResponseWriter) Header() http.Header {
 
 func (trw *testResponseWriter) WriteHeader(statusCode int) {}
 
+func (trw *testResponseWriter) CloseNotify() <-chan bool {
+	return nil
+}
+
 func newTestCache(t *testing.T) *fileSystemCache {
 	t.Helper()
 

--- a/cache/tmp_file_response_writer.go
+++ b/cache/tmp_file_response_writer.go
@@ -25,6 +25,11 @@ type TmpFileResponseWriter struct {
 }
 
 func NewTmpFileResponseWriter(rw http.ResponseWriter, dir string) (*TmpFileResponseWriter, error) {
+	_, ok := rw.(http.CloseNotifier)
+	if !ok {
+		return nil, fmt.Errorf("the response writer does not implement http.CloseNotifier")
+	}
+
 	f, err := ioutil.TempFile(dir, "tmp")
 	if err != nil {
 		return nil, fmt.Errorf("cannot create temporary file in %q: %w", dir, err)
@@ -120,6 +125,7 @@ func (rw *TmpFileResponseWriter) GetCapturedContentEncoding() string {
 
 // CloseNotify implements http.CloseNotifier
 func (rw *TmpFileResponseWriter) CloseNotify() <-chan bool {
+	// nolint:forcetypeassert // it is guaranteed by NewTmpFileResponseWriter
 	// The rw.FSResponseWriter must implement http.CloseNotifier.
 	return rw.ResponseWriter.(http.CloseNotifier).CloseNotify()
 }

--- a/cache/tmp_file_response_writer_test.go
+++ b/cache/tmp_file_response_writer_test.go
@@ -38,6 +38,10 @@ func (r *FakeResponse) WriteHeader(status int) {
 	r.status = status
 }
 
+func (r *FakeResponse) CloseNotify() <-chan bool {
+	return nil
+}
+
 const testTmpWriterDir = "./test-tmp-data"
 
 func init() {

--- a/config/config.go
+++ b/config/config.go
@@ -79,6 +79,8 @@ func (c *Config) String() string {
 
 func withoutSensitiveInfo(config *Config) *Config {
 	const pswPlaceHolder = "XXX"
+
+	// nolint: forcetypeassert // no need to check type, it is specified by function.
 	c := deepcopy.Copy(config).(*Config)
 	for i := range c.Users {
 		c.Users[i].Password = pswPlaceHolder

--- a/main.go
+++ b/main.go
@@ -232,6 +232,7 @@ func serveHTTP(rw http.ResponseWriter, r *http.Request) {
 	switch r.URL.Path {
 	case "/favicon.ico":
 	case "/metrics":
+		// nolint:forcetypeassert // We will cover this by tests as we control what is stored.
 		an := allowedNetworksMetrics.Load().(*config.Networks)
 		if !an.Contains(r.RemoteAddr) {
 			err := fmt.Errorf("connections to /metrics are not allowed from %s", r.RemoteAddr)
@@ -243,15 +244,17 @@ func serveHTTP(rw http.ResponseWriter, r *http.Request) {
 		promHandler.ServeHTTP(rw, r)
 	case "/", "/query":
 		var err error
-
+		// nolint:forcetypeassert // We will cover this by tests as we control what is stored.
 		proxyHandler := proxyHandler.Load().(*ProxyHandler)
 		r.RemoteAddr = proxyHandler.GetRemoteAddr(r)
 
 		var an *config.Networks
 		if r.TLS != nil {
+			// nolint:forcetypeassert // We will cover this by tests as we control what is stored.
 			an = allowedNetworksHTTPS.Load().(*config.Networks)
 			err = fmt.Errorf("https connections are not allowed from %s", r.RemoteAddr)
 		} else {
+			// nolint:forcetypeassert // We will cover this by tests as we control what is stored.
 			an = allowedNetworksHTTP.Load().(*config.Networks)
 			err = fmt.Errorf("http connections are not allowed from %s", r.RemoteAddr)
 		}

--- a/proxy.go
+++ b/proxy.go
@@ -253,7 +253,12 @@ func (rp *reverseProxy) proxyRequest(s *scope, rw ResponseWriterWithCode, srw *s
 	ctx, ctxCancel := context.WithCancel(ctx)
 	defer ctxCancel()
 	// rw must implement http.CloseNotifier.
-	ch := rw.(http.CloseNotifier).CloseNotify()
+	rwc, ok := rw.(http.CloseNotifier)
+	if !ok {
+		panic("BUG: the wrapped ResponseWriter must implement http.CloseNotifier")
+	}
+
+	ch := rwc.CloseNotify()
 	go func() {
 		select {
 		case <-ch:


### PR DESCRIPTION
## Description

<!--  Please explain the object of this PR and the changes you made.
A reference to a github issue would be appreciated. --> 

It was hard to apply a consistent strategy to deal with the type assertions. I'll explain my reasoning:
- If a constructor was available `NewType` I added an assertion in the constructor
- If a constructor wasn't available and access to internal variables was required (which was the case for `statResponseWriter` I added a Panic.
- For the atomic values I added a nolint statement given that access to these values is only done from the `applyConfig` method. There is probably an opportunity here to refactor the config loading so we can enforce this access.

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [ ] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
