### PR TITLE
Clarification on on_cache query parameter

### DIFF
--- a/docs/content/en/configuration/caching.md
+++ b/docs/content/en/configuration/caching.md
@@ -11,7 +11,9 @@ Response caching is enabled by assigning cache name to user. Multiple users may 
 
 Currently only `SELECT` responses are cached.
 
-Caching is disabled for request with `no_cache=1` in query string.
+Caching is disabled for request with `no_cache=1` as an http query parameter. 
+There's no support for similar feature within SQL query.
+
 
 Optional cache namespace may be passed in query string as `cache_namespace=aaaa`. This allows caching
 distinct responses for the identical query under distinct cache namespaces. Additionally,


### PR DESCRIPTION
It was unclear if documentation meant SQL or http query. Clarified based on #110

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [ ] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
