### PR TITLE
add request packet size token limit

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -258,6 +258,14 @@ max_execution_time: <duration> | optional | default = 0
 # By default there are no per-minute limits
 requests_per_minute: <int> | optional | default = 0
 
+# The burst of request packet size token bucket for user
+# By default there are no request packet size limits
+request_packet_size_tokens_burst: <byte_size> | optional | default = 0
+
+# The request packet size tokens produced rate per second for user
+# By default there are no request packet size limits
+request_packet_size_tokens_rate: <byte_size> | optional | default = 0
+
 # Maximum number of requests waiting for execution in the queue.
 # By default requests are executed without waiting in the queue
 max_queue_size: <int> | optional | default = 0
@@ -361,6 +369,14 @@ max_execution_time: <duration> | optional | default = 0
 # Maximum number of requests per minute for user.
 # By default there are no per-minute limits
 requests_per_minute: <int> | optional | default = 0
+
+# The burst of request packet size token bucket for user
+# By default there are no request packet size limits
+request_packet_size_tokens_burst: <byte_size> | optional | default = 0
+
+# The request packet size tokens produced rate per second for user
+# By default there are no request packet size limits
+request_packet_size_tokens_rate: <byte_size> | optional | default = 0
 
 # Maximum number of requests waiting for execution in the queue.
 # By default requests are executed without waiting in the queue

--- a/config/config.go
+++ b/config/config.go
@@ -544,17 +544,13 @@ type User struct {
 	// if omitted or zero - no limits would be applied
 	ReqPerMin uint32 `yaml:"requests_per_minute,omitempty"`
 
-	// The burst of summary upload packet size in a period of time(eg.10s) for user
+	// The burst of request packet size token bucket for user
 	// if omitted or zero - no limits would be applied
-	PacketSizeTokenLimitBurst int `yaml:"packet_size_token_limit_burst,omitempty"`
+	ReqPacketSizeTokensBurst ByteSize `yaml:"request_packet_size_tokens_burst,omitempty"`
 
-	// packet size token produced rate limit
+	// The request packet size tokens produced rate per second for user
 	// if omitted or zero - no limits would be applied
-	PacketSizeTokenRate float64 `yaml:"packet_size_token_rate,omitempty"`
-
-	// packet size unit
-	// if omitted by empty - GB would be applied
-	PacketSizeUnit string `yaml:"packet_size_unit,omitempty"`
+	ReqPacketSizeTokensRate ByteSize `yaml:"request_packet_size_tokens_rate,omitempty"`
 
 	// Maximum number of queries waiting for execution in the queue
 	// if omitted or zero - queries are executed without waiting
@@ -627,8 +623,8 @@ func (u *User) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 
-	if u.PacketSizeTokenLimitBurst > 0 && u.PacketSizeTokenRate == 0 {
-		return fmt.Errorf("`packet_size_token_rate` must be set if `packet_size_token_limit_burst` is set for %q", u.Name)
+	if u.ReqPacketSizeTokensBurst > 0 && u.ReqPacketSizeTokensRate == 0 {
+		return fmt.Errorf("`request_packet_size_tokens_rate` must be set if `request_packet_size_tokens_burst` is set for %q", u.Name)
 	}
 
 	return checkOverflow(u.XXX, fmt.Sprintf("user %q", u.Name))
@@ -842,17 +838,13 @@ type ClusterUser struct {
 	// if omitted or zero - no limits would be applied
 	ReqPerMin uint32 `yaml:"requests_per_minute,omitempty"`
 
-	// The burst of summary upload packet size in a period of time(eg.10s) for user
+	// The burst of request packet size token bucket for user
 	// if omitted or zero - no limits would be applied
-	PacketSizeTokenLimitBurst int `yaml:"packet_size_token_limit_burst,omitempty"`
+	ReqPacketSizeTokensBurst ByteSize `yaml:"request_packet_size_tokens_burst,omitempty"`
 
-	// packet size token produced rate limit
+	// The request packet size tokens produced rate for user
 	// if omitted or zero - no limits would be applied
-	PacketSizeTokenRate float64 `yaml:"packet_size_token_rate,omitempty"`
-
-	// packet size unit
-	// if omitted by empty - B would be applied
-	PacketSizeUnit string `yaml:"packet_size_unit,omitempty"`
+	ReqPacketSizeTokensRate ByteSize `yaml:"request_packet_size_tokens_rate,omitempty"`
 
 	// Maximum number of queries waiting for execution in the queue
 	// if omitted or zero - queries are executed without waiting
@@ -889,8 +881,8 @@ func (cu *ClusterUser) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return fmt.Errorf("`max_queue_size` must be set if `max_queue_time` is set for %q", cu.Name)
 	}
 
-	if cu.PacketSizeTokenLimitBurst > 0 && cu.PacketSizeTokenRate == 0 {
-		return fmt.Errorf("`packet_size_token_rate` must be set if `packet_size_token_limit_burst` is set for %q", cu.Name)
+	if cu.ReqPacketSizeTokensBurst > 0 && cu.ReqPacketSizeTokensRate == 0 {
+		return fmt.Errorf("`request_packet_size_tokens_rate` must be set if `request_packet_size_tokens_burst` is set for %q", cu.Name)
 	}
 
 	return checkOverflow(cu.XXX, fmt.Sprintf("cluster.user %q", cu.Name))

--- a/config/config.go
+++ b/config/config.go
@@ -544,6 +544,18 @@ type User struct {
 	// if omitted or zero - no limits would be applied
 	ReqPerMin uint32 `yaml:"requests_per_minute,omitempty"`
 
+	// The burst of summary upload packet size in a period of time(eg.10s) for user
+	// if omitted or zero - no limits would be applied
+	PacketSizeTokenLimitBurst int `yaml:"packet_size_token_limit_burst,omitempty"`
+
+	// packet size token produced rate limit
+	// if omitted or zero - no limits would be applied
+	PacketSizeTokenRate float64 `yaml:"packet_size_token_rate,omitempty"`
+
+	// packet size unit
+	// if omitted by empty - GB would be applied
+	PacketSizeUnit string `yaml:"packet_size_unit,omitempty"`
+
 	// Maximum number of queries waiting for execution in the queue
 	// if omitted or zero - queries are executed without waiting
 	// in the queue
@@ -613,6 +625,10 @@ func (u *User) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if s := strings.Split(u.Name, "*"); !(len(s) == 2 && (s[0] == "" || s[1] == "")) {
 			return fmt.Errorf("user name %q marked 'is_wildcared' does not match 'prefix*' or '*suffix' or '*'", u.Name)
 		}
+	}
+
+	if u.PacketSizeTokenLimitBurst > 0 && u.PacketSizeTokenRate == 0 {
+		return fmt.Errorf("`packet_size_token_rate` must be set if `packet_size_token_limit_burst` is set for %q", u.Name)
 	}
 
 	return checkOverflow(u.XXX, fmt.Sprintf("user %q", u.Name))
@@ -826,6 +842,18 @@ type ClusterUser struct {
 	// if omitted or zero - no limits would be applied
 	ReqPerMin uint32 `yaml:"requests_per_minute,omitempty"`
 
+	// The burst of summary upload packet size in a period of time(eg.10s) for user
+	// if omitted or zero - no limits would be applied
+	PacketSizeTokenLimitBurst int `yaml:"packet_size_token_limit_burst,omitempty"`
+
+	// packet size token produced rate limit
+	// if omitted or zero - no limits would be applied
+	PacketSizeTokenRate float64 `yaml:"packet_size_token_rate,omitempty"`
+
+	// packet size unit
+	// if omitted by empty - B would be applied
+	PacketSizeUnit string `yaml:"packet_size_unit,omitempty"`
+
 	// Maximum number of queries waiting for execution in the queue
 	// if omitted or zero - queries are executed without waiting
 	// in the queue
@@ -859,6 +887,10 @@ func (cu *ClusterUser) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	if cu.MaxQueueTime > 0 && cu.MaxQueueSize == 0 {
 		return fmt.Errorf("`max_queue_size` must be set if `max_queue_time` is set for %q", cu.Name)
+	}
+
+	if cu.PacketSizeTokenLimitBurst > 0 && cu.PacketSizeTokenRate == 0 {
+		return fmt.Errorf("`packet_size_token_rate` must be set if `packet_size_token_limit_burst` is set for %q", cu.Name)
 	}
 
 	return checkOverflow(cu.XXX, fmt.Sprintf("cluster.user %q", cu.Name))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -457,6 +457,16 @@ func TestBadConfig(t *testing.T) {
 			"`max_queue_size` must be set if `max_queue_time` is set for \"default\"",
 		},
 		{
+			"packet size token burst and rate on user",
+			"testdata/bad.packet_size_token_burst_rate_user.yml",
+			"`packet_size_token_rate` must be set if `packet_size_token_limit_burst` is set for \"default\"",
+		},
+		{
+			"packet size token burst and rate on user on cluster_user",
+			"testdata/bad.packet_size_token_burst_rate_cluster_user.yml",
+			"`packet_size_token_rate` must be set if `packet_size_token_limit_burst` is set for \"default\"",
+		},
+		{
 			"cache max size",
 			"testdata/bad.cache_max_size.yml",
 			"cannot parse byte size \"-10B\": it must be positive float followed by optional units. For example, 1.5Gb, 3T",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -459,12 +459,12 @@ func TestBadConfig(t *testing.T) {
 		{
 			"packet size token burst and rate on user",
 			"testdata/bad.packet_size_token_burst_rate_user.yml",
-			"`packet_size_token_rate` must be set if `packet_size_token_limit_burst` is set for \"default\"",
+			"`request_packet_size_tokens_rate` must be set if `request_packet_size_tokens_burst` is set for \"default\"",
 		},
 		{
 			"packet size token burst and rate on user on cluster_user",
 			"testdata/bad.packet_size_token_burst_rate_cluster_user.yml",
-			"`packet_size_token_rate` must be set if `packet_size_token_limit_burst` is set for \"default\"",
+			"`request_packet_size_tokens_rate` must be set if `request_packet_size_tokens_burst` is set for \"default\"",
 		},
 		{
 			"cache max size",

--- a/config/testdata/bad.packet_size_token_burst_rate_cluster_user.yml
+++ b/config/testdata/bad.packet_size_token_burst_rate_cluster_user.yml
@@ -13,4 +13,4 @@ clusters:
     nodes: ["127.0.0.1:8123"]
     users:
       - name: "default"
-        packet_size_token_limit_burst: 10
+        request_packet_size_tokens_burst: 10

--- a/config/testdata/bad.packet_size_token_burst_rate_cluster_user.yml
+++ b/config/testdata/bad.packet_size_token_burst_rate_cluster_user.yml
@@ -1,0 +1,16 @@
+server:
+  http:
+    listen_addr: ":8080"
+    allowed_networks: ["127.0.0.1"]
+
+users:
+  - name: "default"
+    to_cluster: "cluster"
+    to_user: "default"
+
+clusters:
+  - name: "cluster"
+    nodes: ["127.0.0.1:8123"]
+    users:
+      - name: "default"
+        packet_size_token_limit_burst: 10

--- a/config/testdata/bad.packet_size_token_burst_rate_user.yml
+++ b/config/testdata/bad.packet_size_token_burst_rate_user.yml
@@ -7,7 +7,7 @@ users:
   - name: "default"
     to_cluster: "cluster"
     to_user: "default"
-    packet_size_token_limit_burst: 10
+    request_packet_size_tokens_burst: 10
 
 clusters:
   - name: "cluster"

--- a/config/testdata/bad.packet_size_token_burst_rate_user.yml
+++ b/config/testdata/bad.packet_size_token_burst_rate_user.yml
@@ -1,0 +1,14 @@
+server:
+  http:
+    listen_addr: ":8080"
+    allowed_networks: ["127.0.0.1"]
+
+users:
+  - name: "default"
+    to_cluster: "cluster"
+    to_user: "default"
+    packet_size_token_limit_burst: 10
+
+clusters:
+  - name: "cluster"
+    nodes: ["127.0.0.1:8123"]

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/redis/go-redis/v9 v9.0.2
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/time v0.3.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -11,9 +11,7 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bsm/ginkgo/v2 v2.5.0 h1:aOAnND1T40wEdAtkGSkvSICWeQ8L3UASX7YVCqQx+eQ=
-github.com/bsm/ginkgo/v2 v2.5.0/go.mod h1:AiKlXPm7ItEHNc/2+OkrNG4E0ITzojb9/xWzvQ9XZ9w=
 github.com/bsm/gomega v1.20.0 h1:JhAwLmtRzXFTx2AkALSLa8ijZafntmhSoU63Ok18Uq8=
-github.com/bsm/gomega v1.20.0/go.mod h1:JifAceMQ4crZIWYUKrlGcmbN3bqHogVTADMD2ATsbwk=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -129,6 +127,8 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
+golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=

--- a/proxy.go
+++ b/proxy.go
@@ -831,5 +831,12 @@ func (rp *reverseProxy) getScope(req *http.Request) (*scope, int, error) {
 	}
 
 	s := newScope(req, u, c, cu, sessionId, sessionTimeout)
+
+	q, err := getFullQuery(req)
+	if err != nil {
+		return nil, http.StatusBadRequest, fmt.Errorf("%s: cannot read query: %s", s, err)
+	}
+	s.requestBodyBytes = len(q)
+
 	return s, 0, nil
 }

--- a/proxy.go
+++ b/proxy.go
@@ -834,9 +834,8 @@ func (rp *reverseProxy) getScope(req *http.Request) (*scope, int, error) {
 
 	q, err := getFullQuery(req)
 	if err != nil {
-		return nil, http.StatusBadRequest, fmt.Errorf("%s: cannot read query: %s", s, err)
+		return nil, http.StatusBadRequest, fmt.Errorf("%s: cannot read query: %w", s, err)
 	}
-	s.requestBodyBytes = len(q)
-
+	s.requestPacketSize = len(q)
 	return s, 0, nil
 }

--- a/scope.go
+++ b/scope.go
@@ -17,6 +17,7 @@ import (
 	"github.com/contentsquare/chproxy/config"
 	"github.com/contentsquare/chproxy/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/time/rate"
 )
 
 type scopeID uint64
@@ -50,6 +51,8 @@ type scope struct {
 	canceled bool
 
 	labels prometheus.Labels
+
+	requestBodyBytes int
 }
 
 func newScope(req *http.Request, u *user, c *cluster, cu *clusterUser, sessionId string, sessionTimeout int) *scope {
@@ -233,6 +236,28 @@ func (s *scope) inc() error {
 		s.user.rateLimiter.dec()
 		s.clusterUser.rateLimiter.dec()
 		return err
+	}
+
+	// packet size token limit
+	if s.user.packetSizeTokenLimitBurst > 0 {
+		tl := s.user.packetSizeTokenLimiter
+		ctx, cancel := context.WithTimeout(context.TODO(), s.user.maxExecutionTime)
+		defer cancel()
+		err = tl.WaitN(ctx, int(formatPacketSizeByUnit(s.requestBodyBytes, s.user.packetSizeUnit))) // request packet size num by packet size unit
+		if err != nil {
+			return fmt.Errorf("limits for user %q is exceeded: packet_size_token_limit_burst limit: %d%s",
+				s.user.name, s.user.packetSizeTokenLimitBurst, s.user.packetSizeUnit)
+		}
+	}
+	if s.clusterUser.packetSizeTokenLimitBurst > 0 {
+		tl := s.clusterUser.packetSizeTokenLimiter
+		ctx, cancel := context.WithTimeout(context.TODO(), s.clusterUser.maxExecutionTime)
+		defer cancel()
+		err = tl.WaitN(ctx, int(formatPacketSizeByUnit(s.requestBodyBytes, s.clusterUser.packetSizeUnit))) // request packet size num by packet size unit
+		if err != nil {
+			return fmt.Errorf("limits for cluster user %q is exceeded: packet_size_token_limit_burst limit: %d%s",
+				s.clusterUser.name, s.clusterUser.packetSizeTokenLimitBurst, s.clusterUser.packetSizeUnit)
+		}
 	}
 
 	s.host.inc()
@@ -469,6 +494,11 @@ type user struct {
 	reqPerMin   uint32
 	rateLimiter rateLimiter
 
+	packetSizeTokenLimiter    *rate.Limiter
+	packetSizeUnit            string
+	packetSizeTokenLimitBurst int
+	packetSizeTokenRate       float64
+
 	queueCh      chan struct{}
 	maxQueueTime time.Duration
 
@@ -541,22 +571,26 @@ func (up usersProfile) newUser(u config.User) (*user, error) {
 	}
 
 	return &user{
-		name:                 u.Name,
-		password:             u.Password,
-		toCluster:            u.ToCluster,
-		toUser:               u.ToUser,
-		maxConcurrentQueries: u.MaxConcurrentQueries,
-		maxExecutionTime:     time.Duration(u.MaxExecutionTime),
-		reqPerMin:            u.ReqPerMin,
-		queueCh:              queueCh,
-		maxQueueTime:         time.Duration(u.MaxQueueTime),
-		allowedNetworks:      u.AllowedNetworks,
-		denyHTTP:             u.DenyHTTP,
-		denyHTTPS:            u.DenyHTTPS,
-		allowCORS:            u.AllowCORS,
-		isWildcarded:         u.IsWildcarded,
-		cache:                cc,
-		params:               params,
+		name:                      u.Name,
+		password:                  u.Password,
+		toCluster:                 u.ToCluster,
+		toUser:                    u.ToUser,
+		maxConcurrentQueries:      u.MaxConcurrentQueries,
+		maxExecutionTime:          time.Duration(u.MaxExecutionTime),
+		reqPerMin:                 u.ReqPerMin,
+		queueCh:                   queueCh,
+		maxQueueTime:              time.Duration(u.MaxQueueTime),
+		packetSizeTokenLimiter:    rate.NewLimiter(rate.Limit(u.PacketSizeTokenRate), u.PacketSizeTokenLimitBurst),
+		packetSizeTokenLimitBurst: u.PacketSizeTokenLimitBurst,
+		packetSizeUnit:            u.PacketSizeUnit,
+		packetSizeTokenRate:       u.PacketSizeTokenRate,
+		allowedNetworks:           u.AllowedNetworks,
+		denyHTTP:                  u.DenyHTTP,
+		denyHTTPS:                 u.DenyHTTPS,
+		allowCORS:                 u.AllowCORS,
+		isWildcarded:              u.IsWildcarded,
+		cache:                     cc,
+		params:                    params,
 	}, nil
 }
 
@@ -574,6 +608,11 @@ type clusterUser struct {
 
 	queueCh      chan struct{}
 	maxQueueTime time.Duration
+
+	packetSizeTokenLimiter    *rate.Limiter
+	packetSizeUnit            string
+	packetSizeTokenLimitBurst int
+	packetSizeTokenRate       float64
 
 	allowedNetworks config.Networks
 	isWildcarded    bool
@@ -602,14 +641,18 @@ func newClusterUser(cu config.ClusterUser) *clusterUser {
 		queueCh = make(chan struct{}, cu.MaxQueueSize)
 	}
 	return &clusterUser{
-		name:                 cu.Name,
-		password:             cu.Password,
-		maxConcurrentQueries: cu.MaxConcurrentQueries,
-		maxExecutionTime:     time.Duration(cu.MaxExecutionTime),
-		reqPerMin:            cu.ReqPerMin,
-		queueCh:              queueCh,
-		maxQueueTime:         time.Duration(cu.MaxQueueTime),
-		allowedNetworks:      cu.AllowedNetworks,
+		name:                      cu.Name,
+		password:                  cu.Password,
+		maxConcurrentQueries:      cu.MaxConcurrentQueries,
+		maxExecutionTime:          time.Duration(cu.MaxExecutionTime),
+		reqPerMin:                 cu.ReqPerMin,
+		packetSizeTokenLimiter:    rate.NewLimiter(rate.Limit(cu.PacketSizeTokenRate), cu.PacketSizeTokenLimitBurst),
+		packetSizeTokenLimitBurst: cu.PacketSizeTokenLimitBurst,
+		packetSizeUnit:            cu.PacketSizeUnit,
+		packetSizeTokenRate:       cu.PacketSizeTokenRate,
+		queueCh:                   queueCh,
+		maxQueueTime:              time.Duration(cu.MaxQueueTime),
+		allowedNetworks:           cu.AllowedNetworks,
 	}
 }
 

--- a/utils.go
+++ b/utils.go
@@ -294,3 +294,22 @@ func calcCredentialHash(user string, pwd string) (uint32, error) {
 	_, err := h.Write([]byte(user + pwd))
 	return h.Sum32(), err
 }
+
+func formatPacketSizeByUnit(packetBytes int, unit string) float64 {
+	packetSizeNum := float64(0)
+	switch unit {
+	case "KB":
+		packetSizeNum = float64(packetBytes) / float64(1024)
+	case "MB":
+		packetSizeNum = float64(packetBytes) / float64(1024*1024)
+	case "GB":
+		packetSizeNum = float64(packetBytes) / float64(1024*1024*1024)
+	case "TB":
+		packetSizeNum = float64(packetBytes) / float64(1024*1024*1024*1024)
+	case "PB":
+		packetSizeNum = float64(packetBytes) / float64(1024*1024*1024*1024*1024)
+	default:
+		packetSizeNum = float64(packetBytes) / float64(1)
+	}
+	return packetSizeNum
+}

--- a/utils.go
+++ b/utils.go
@@ -294,22 +294,3 @@ func calcCredentialHash(user string, pwd string) (uint32, error) {
 	_, err := h.Write([]byte(user + pwd))
 	return h.Sum32(), err
 }
-
-func formatPacketSizeByUnit(packetBytes int, unit string) float64 {
-	packetSizeNum := float64(0)
-	switch unit {
-	case "KB":
-		packetSizeNum = float64(packetBytes) / float64(1024)
-	case "MB":
-		packetSizeNum = float64(packetBytes) / float64(1024*1024)
-	case "GB":
-		packetSizeNum = float64(packetBytes) / float64(1024*1024*1024)
-	case "TB":
-		packetSizeNum = float64(packetBytes) / float64(1024*1024*1024*1024)
-	case "PB":
-		packetSizeNum = float64(packetBytes) / float64(1024*1024*1024*1024*1024)
-	default:
-		packetSizeNum = float64(packetBytes) / float64(1)
-	}
-	return packetSizeNum
-}


### PR DESCRIPTION
## Description

Limit per-user requests occupied bandwidth, It can limit the large number of offline data import queries, thereby reducing other query failures. It is valuable in the scene of corporate promotions such as double 11 and 618.
https://github.com/ContentSquare/chproxy/issues/297

## Pull request type

Feature

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] Documentation content changes
- [x] Other (please describe):


### Checklist

- [x] Linter passes correctly
- [x] Add tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary

