### PR TITLE
add ca-certificates package to enable verifying lets encrypt certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian
 
+RUN apt update && apt install -y ca-certificates
+
 COPY chproxy /
 
 EXPOSE 9090


### PR DESCRIPTION


## Description
In current docker image, it is not possible to connect to Clickhouse which has let's encrypt certificates. It fails with this error

```
ERROR: 2023/02/15 13:13:16 scope.go:699: error while health-checking "XXX.example.com" host: cannot send request in 30.873573ms: Get "XXX.example.com/?query=SELECT%201%2B1": x509: certificate signed by unknown authority
```

This PR fixes it by adding `ca-certificates` package into base image.

<!--  Please explain the object of this PR and the changes you made.
A reference to a github issue would be appreciated. --> 

## Pull request type
Updated docker image
<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ x ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [ x  ] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [ x ] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
