### PR TITLE
support custom query_id

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -35,7 +35,7 @@ var nextScopeID = uint64(time.Now().UnixNano())
 
 type scope struct {
 	startTime   time.Time
-	id          scopeID
+	id          string
 	host        *host
 	cluster     *cluster
 	user        *user
@@ -64,9 +64,13 @@ func newScope(req *http.Request, u *user, c *cluster, cu *clusterUser, sessionId
 	if addr, ok := req.Context().Value(http.LocalAddrContextKey).(net.Addr); ok {
 		localAddr = addr.String()
 	}
+	id := req.URL.Query().Get("query_id")
+	if id == "" {
+		id = newScopeID().String()
+	}
 	s := &scope{
 		startTime:      time.Now(),
-		id:             newScopeID(),
+		id:             id,
 		host:           h,
 		cluster:        c,
 		user:           u,
@@ -393,7 +397,7 @@ func (s *scope) decorateRequest(req *http.Request) (*http.Request, url.Values) {
 	}
 
 	// Set query_id as scope_id to have possibility to kill query if needed.
-	params.Set("query_id", s.id.String())
+	params.Set("query_id", s.id)
 	// Set session_timeout an idle timeout for session
 	params.Set("session_timeout", strconv.Itoa(s.sessionTimeout))
 

--- a/scope_test.go
+++ b/scope_test.go
@@ -38,7 +38,7 @@ func TestRunningQueries(t *testing.T) {
 	u1 := &user{
 		maxConcurrentQueries: 1,
 	}
-	s := &scope{id: newScopeID()}
+	s := &scope{id: newScopeID().String()}
 	s.host = c.getHost()
 	s.cluster = c
 	s.user = u1
@@ -84,7 +84,7 @@ func TestRunningQueries(t *testing.T) {
 	u2 := &user{
 		maxConcurrentQueries: 1,
 	}
-	s = &scope{id: newScopeID()}
+	s = &scope{id: newScopeID().String()}
 	s.host = c.getHost()
 	s.cluster = c
 	s.user = u2
@@ -405,7 +405,7 @@ func TestDecorateRequest(t *testing.T) {
 		}
 		req.Header.Set("Content-Type", tc.contentType)
 		s := &scope{
-			id:          newScopeID(),
+			id:          newScopeID().String(),
 			clusterUser: &clusterUser{},
 			user: &user{
 				params: tc.userParams,
@@ -573,7 +573,7 @@ func testGetUser() *user {
 }
 
 func testGetScope(c *cluster, u *user, cu *clusterUser, sessionId string) *scope {
-	s := &scope{id: newScopeID()}
+	s := &scope{id: newScopeID().String()}
 	s.cluster = c
 	s.host = c.getHost()
 	if sessionId != "" {


### PR DESCRIPTION
In some scenarios, the client needs to use a custom query_id to pass to the clickhouse query, so as to track the execution of the query when the query is being executed. And chproxy currently can only return query_id after the query is completed


#164 
