### PR TITLE
feat(proxy): Include a X-Cache Header

### DIFF
--- a/docs/content/en/configuration/caching.md
+++ b/docs/content/en/configuration/caching.md
@@ -62,3 +62,9 @@ User Y will get the cached response from user X's query.
 
 Since 1.20.0, the cache is specific for each user by default since it's better in terms of security.
 It's possible to use the previous behavior by setting the following property of the cache in the config file `shared_with_all_users = true` 
+
+#### Detecting Cache Hits
+
+`Chproxy` will respond with an `X-Cache` header with a value of `HIT` if it returned a response from either the local or the distributed cache. Otherwise `X-Cache` will be set to `MISS`. 
+If the response couldn't be cached due to the configuration (e.g. a payload that is too large), `N/A` will be returned. This can be used for example to determine 
+whether the ClickHouse query stats in the response can be trusted or are cached responses.


### PR DESCRIPTION
## Description

X-Cache will be set to HIT if a response came from the Cache, otherwise it will be set to MISS. As explained in the #288, this can help to determine the accuracy of the ClickHouse stats in the response (and there might be other use cases).

Fixes #288

<!--  Please explain the object of this PR and the changes you made.
A reference to a github issue would be appreciated. --> 

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [x] Linter passes correctly
- [x] Add tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
