### PR TITLE
#319 Fixed Redis Cluster Crossslot Issue

### DIFF
--- a/cache/redis_cache.go
+++ b/cache/redis_cache.go
@@ -254,6 +254,7 @@ func (r *redisCache) Put(reader io.Reader, contentMetadata ContentMetadata, key 
 	// nolint:gosec // not security sensitve, only used internally.
 	random := strconv.Itoa(rand.Int())
 	stringKeyTmp := "{" + stringKey + "}" + random + "_tmp"
+	
 	ctxSet, cancelFuncSet := context.WithTimeout(context.Background(), putTimeout)
 	defer cancelFuncSet()
 	err := r.client.Set(ctxSet, stringKeyTmp, medatadata, r.expire).Err()

--- a/cache/redis_cache.go
+++ b/cache/redis_cache.go
@@ -253,8 +253,7 @@ func (r *redisCache) Put(reader io.Reader, contentMetadata ContentMetadata, key 
 	// then it switches the full result to the "real" stringKey available for other goroutines
 	// nolint:gosec // not security sensitve, only used internally.
 	random := strconv.Itoa(rand.Int())
-	stringKeyTmp := stringKey + random + "_tmp"
-
+	stringKeyTmp := "{" + stringKey + "}" + random + "_tmp"
 	ctxSet, cancelFuncSet := context.WithTimeout(context.Background(), putTimeout)
 	defer cancelFuncSet()
 	err := r.client.Set(ctxSet, stringKeyTmp, medatadata, r.expire).Err()

--- a/cache/redis_cache.go
+++ b/cache/redis_cache.go
@@ -254,7 +254,7 @@ func (r *redisCache) Put(reader io.Reader, contentMetadata ContentMetadata, key 
 	// nolint:gosec // not security sensitve, only used internally.
 	random := strconv.Itoa(rand.Int())
 	stringKeyTmp := "{" + stringKey + "}" + random + "_tmp"
-	
+
 	ctxSet, cancelFuncSet := context.WithTimeout(context.Background(), putTimeout)
 	defer cancelFuncSet()
 	err := r.client.Set(ctxSet, stringKeyTmp, medatadata, r.expire).Err()

--- a/cache/redis_cache.go
+++ b/cache/redis_cache.go
@@ -253,11 +253,11 @@ func (r *redisCache) Put(reader io.Reader, contentMetadata ContentMetadata, key 
 	// then it switches the full result to the "real" stringKey available for other goroutines
 	// nolint:gosec // not security sensitve, only used internally.
 	random := strconv.Itoa(rand.Int())
-	// Redis RENAME is considered to be a multikey operation. In Cluster mode, both oldkey and renamedkey must be in the same hash slot, 
+	// Redis RENAME is considered to be a multikey operation. In Cluster mode, both oldkey and renamedkey must be in the same hash slot,
 	// Refer Redis Documentation here: https://redis.io/commands/rename/
-	// To solve this,we need to force the temporary key to be in the same hash slot. We can do this by adding hashtag to the 
-	// actual part of the temporary key. When the key contains a "{...}" pattern, only the substring between the braces, "{" and "}," 
-	// is hashed to obtain the hash slot. 
+	// To solve this,we need to force the temporary key to be in the same hash slot. We can do this by adding hashtag to the
+	// actual part of the temporary key. When the key contains a "{...}" pattern, only the substring between the braces, "{" and "},"
+	// is hashed to obtain the hash slot.
 	// Refer the hash tags section of Redis documentation here: https://redis.io/docs/reference/cluster-spec/#hash-tags
 	stringKeyTmp := "{" + stringKey + "}" + random + "_tmp"
 

--- a/cache/redis_cache.go
+++ b/cache/redis_cache.go
@@ -253,6 +253,12 @@ func (r *redisCache) Put(reader io.Reader, contentMetadata ContentMetadata, key 
 	// then it switches the full result to the "real" stringKey available for other goroutines
 	// nolint:gosec // not security sensitve, only used internally.
 	random := strconv.Itoa(rand.Int())
+	// Redis RENAME is considered to be a multikey operation. In Cluster mode, both oldkey and renamedkey must be in the same hash slot, 
+	// Refer Redis Documentation here: https://redis.io/commands/rename/
+	// To solve this,we need to force the temporary key to be in the same hash slot. We can do this by adding hashtag to the 
+	// actual part of the temporary key. When the key contains a "{...}" pattern, only the substring between the braces, "{" and "}," 
+	// is hashed to obtain the hash slot. 
+	// Refer the hash tags section of Redis documentation here: https://redis.io/docs/reference/cluster-spec/#hash-tags
 	stringKeyTmp := "{" + stringKey + "}" + random + "_tmp"
 
 	ctxSet, cancelFuncSet := context.WithTimeout(context.Background(), putTimeout)


### PR DESCRIPTION
## Description

Issue Link: https://github.com/ContentSquare/chproxy/issues/319
The issue is occurring while renaming the temporary key with actual key because the hash slot for temporary key (with _tmp suffix) and actual key (without _tmp suffix) should be same. If they are not same, redis will throw an error: 
> (error) CROSSSLOT Keys in request don't hash to the same slot 

To solve this,we need to force the temporary key to be in the same hash slot. We can do this by adding hashtag to the actual part of the temporary key. When the key contains a "{...}" pattern, only the substring between the braces, "{" and "}," is hashed to obtain the hash slot. 

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [x] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Further comments
This change I have tested in my environment with 3 master node - 3 replica node redis cluster. It is working fine.
