### PR TITLE
fix(proxy_handler): Handle spaces in x-forwarded-for header

### DIFF
--- a/proxy_handler.go
+++ b/proxy_handler.go
@@ -74,7 +74,7 @@ func extractFirstMatchFromIPList(ipList string) string {
 	if ipList == "" {
 		return ""
 	}
-	s := strings.Index(ipList, ", ")
+	s := strings.Index(ipList, ",")
 	if s == -1 {
 		s = len(ipList)
 	}
@@ -91,7 +91,7 @@ func parseForwardedHeader(fwd string) string {
 	for _, split := range splits {
 		trimmed := strings.TrimSpace(split)
 		if strings.HasPrefix(strings.ToLower(trimmed), "for=") {
-			forSplits := strings.Split(trimmed, ", ")
+			forSplits := strings.Split(trimmed, ",")
 			if len(forSplits) == 0 {
 				return ""
 			}

--- a/proxy_handler_test.go
+++ b/proxy_handler_test.go
@@ -75,6 +75,19 @@ func TestProxyHandler(t *testing.T) {
 			expectedAddr: "10.0.0.1",
 		},
 		{
+			name: "proxy should forward proxy header Forwarded if set and treat a lack of spaces as an equivalent (issue #326).",
+			proxy: &config.Proxy{
+				Enable: true,
+			},
+			r: &http.Request{
+				RemoteAddr: "127.0.0.1:1234",
+				Header: http.Header{
+					"Forwarded": []string{"for=10.0.0.1,for=10.0.0.3"},
+				},
+			},
+			expectedAddr: "10.0.0.1",
+		},
+		{
 			name: "proxy should properly parse Forwarded header",
 			proxy: &config.Proxy{
 				Enable: true,


### PR DESCRIPTION
## Description

Having spaces or no spaces results in equivalent headers in RFC 7239.

This PR fixes #326 because we treated spaces as mandatory in the Forwarded Header.

<!--  Please explain the object of this PR and the changes you made.
A reference to a github issue would be appreciated. --> 

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [ ] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
