### PR TITLE
Support using the tls config in Redis cache

### DIFF
--- a/cache/async_cache_test.go
+++ b/cache/async_cache_test.go
@@ -277,7 +277,7 @@ func TestAsyncCache_RedisCache_TLS(t *testing.T) {
 	}
 	s := miniredis.NewMiniRedis()
 	if err := s.StartTLS(tlsConfig); err != nil {
-		t.Fatalf("could not start miniredis: %s", err)
+		t.Fatalf("could not start miniredis: %s", err.Error())
 		// not reached
 	}
 	t.Cleanup(s.Close)
@@ -295,7 +295,7 @@ func TestAsyncCache_RedisCache_TLS(t *testing.T) {
 
 	_, err = NewAsyncCache(redisCfg, 1*time.Second)
 	if err != nil {
-		t.Fatalf("could not instanciate redis async cache because of the following error: %s", err)
+		t.Fatalf("could not instanciate redis async cache because of the following error: %s", err.Error())
 	}
 }
 

--- a/cache/redis_cache.go
+++ b/cache/redis_cache.go
@@ -360,7 +360,7 @@ func (r *redisStreamReader) Read(destBuf []byte) (n int, err error) {
 		// Because of the way we fetch from redis, we need to do an extra check because we have no way
 		// to know if redis is really EOF or if the value was expired from cache while reading it
 		if r.readPayloadSize != r.expectedPayloadSize {
-			log.Debugf("error while fetching data from redis payload size doesn't macht")
+			log.Debugf("error while fetching data from redis payload size doesn't match")
 			return 0, &RedisCacheError{key: r.key, readPayloadSize: r.readPayloadSize, expectedPayloadSize: r.expectedPayloadSize}
 		}
 		return 0, io.EOF

--- a/config/config.go
+++ b/config/config.go
@@ -1,12 +1,14 @@
 package config
 
 import (
+	"crypto/tls"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/mohae/deepcopy"
+	"golang.org/x/crypto/acme/autocert"
 	"gopkg.in/yaml.v2"
 )
 
@@ -218,6 +220,40 @@ func (c *HTTP) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return checkOverflow(c.XXX, "http")
 }
 
+// TLS describes generic configuration for TLS connections,
+// it can be used for both HTTPS and Redis TLS.
+type TLS struct {
+	// Certificate and key files for client cert authentication to the server
+	CertFile string   `yaml:"cert_file,omitempty"`
+	KeyFile  string   `yaml:"key_file,omitempty"`
+	Autocert Autocert `yaml:"autocert,omitempty"`
+}
+
+func (c *TLS) BuildTLSConfig(acm *autocert.Manager) (*tls.Config, error) {
+	tlsCfg := tls.Config{
+		PreferServerCipherSuites: true,
+		MinVersion:               tls.VersionTLS12,
+		CurvePreferences: []tls.CurveID{
+			tls.CurveP256,
+			tls.X25519,
+		},
+	}
+	if len(c.KeyFile) > 0 && len(c.CertFile) > 0 {
+		cert, err := tls.LoadX509KeyPair(c.CertFile, c.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("cannot load cert for `https.cert_file`=%q, `https.key_file`=%q: %s",
+				c.CertFile, c.KeyFile, err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	} else {
+		if acm == nil {
+			return nil, fmt.Errorf("autocert manager is not configured")
+		}
+		tlsCfg.GetCertificate = acm.GetCertificate
+	}
+	return &tlsCfg, nil
+}
+
 // HTTPS describes configuration for server to listen HTTPS connections
 // It can be autocert with letsencrypt
 // or custom certificate
@@ -226,11 +262,8 @@ type HTTPS struct {
 	// Default is `:443`
 	ListenAddr string `yaml:"listen_addr,omitempty"`
 
-	// Certificate and key files for client cert authentication to the server
-	CertFile string `yaml:"cert_file,omitempty"`
-	KeyFile  string `yaml:"key_file,omitempty"`
-
-	Autocert Autocert `yaml:"autocert,omitempty"`
+	// TLS configuration
+	TLS `yaml:",inline"`
 
 	NetworksOrGroups NetworksOrGroups `yaml:"allowed_networks,omitempty"`
 

--- a/config/config.go
+++ b/config/config.go
@@ -239,12 +239,12 @@ func (c *TLS) BuildTLSConfig(acm *autocert.Manager) (*tls.Config, error) {
 			tls.CurveP256,
 			tls.X25519,
 		},
-		InsecureSkipVerify: c.InsecureSkipVerify,
+		InsecureSkipVerify: c.InsecureSkipVerify, // nolint: gosec
 	}
 	if len(c.KeyFile) > 0 && len(c.CertFile) > 0 {
 		cert, err := tls.LoadX509KeyPair(c.CertFile, c.KeyFile)
 		if err != nil {
-			return nil, fmt.Errorf("cannot load cert for `cert_file`=%q, `key_file`=%q: %s",
+			return nil, fmt.Errorf("cannot load cert for `cert_file`=%q, `key_file`=%q: %w",
 				c.CertFile, c.KeyFile, err)
 		}
 		tlsCfg.Certificates = []tls.Certificate{cert}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,10 +3,11 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"github.com/contentsquare/chproxy/global/types"
 	"net"
 	"testing"
 	"time"
+
+	"github.com/contentsquare/chproxy/global/types"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -68,9 +69,11 @@ var fullConfig = Config{
 		},
 		HTTPS: HTTPS{
 			ListenAddr: ":443",
-			Autocert: Autocert{
-				CacheDir:     "certs_dir",
-				AllowedHosts: []string{"example.com"},
+			TLS: TLS{
+				Autocert: Autocert{
+					CacheDir:     "certs_dir",
+					AllowedHosts: []string{"example.com"},
+				},
 			},
 			TimeoutCfg: TimeoutCfg{
 				ReadTimeout:  Duration(time.Minute),

--- a/docs/content/en/configuration/default.md
+++ b/docs/content/en/configuration/default.md
@@ -62,6 +62,14 @@ caches:
     # Applicable for cache mode: redis
     # You should use multiple addresses only if they all belong to the same redis cluster.
     redis:
+      # Paths to TLS cert and key files for the redis server.
+      # If you change the cert & key files while chproxy is running, you have to restart chproxy so that it loads them.
+      # Triggering a SIGHUP signal won't work as for the rest of the configuration.
+      cert_file: "redis tls cert file path"
+      key_file: "redis tls key file apth"
+      # Allow to skip the verification of the redis server certificate.
+      insecure_skip_verify: true
+
       addresses:
         - "localhost:16379"
       username: "user"


### PR DESCRIPTION
## Description

The main change in this PR is to support using the TLS config in the Redis cache. It also does a minor refactor to let HTTPS and Redis TLS can share the same TLS build logic.

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [ ] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
