### PR TITLE
feat(config): Support environment variable replacement syntax.

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -930,5 +931,34 @@ connection_pool:
 		t.Fatalf("the stringify version of fullConfig is not what it's expected: %s",
 			cmp.Diff(tested, expected))
 
+	}
+}
+
+func TestConfigReplaceEnvVars(t *testing.T) {
+	var testCases = []struct {
+		name             string
+		file             string
+		expectedPassword string
+	}{
+		{
+			"replace env vars with the style of ${}",
+			"testdata/envvars.simple.yml",
+			"MyPassword",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			os.Setenv("CHPROXY_PASSWORD", tc.expectedPassword)
+
+			cfg, err := LoadFile(tc.file)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			got := cfg.Users[0].Password
+			if got != tc.expectedPassword {
+				t.Fatalf("got password %v; expected to have: %v", got, tc.expectedPassword)
+			}
+		})
 	}
 }

--- a/config/testdata/envvars.simple.yml
+++ b/config/testdata/envvars.simple.yml
@@ -1,0 +1,14 @@
+server:
+  http:
+    listen_addr: ":8080"
+    allowed_networks: ["127.0.0.1"]
+
+users:
+  - name: "default"
+    password: ${CHPROXY_PASSWORD}
+    to_cluster: "cluster"
+    to_user: "default"
+
+clusters:
+  - name: "cluster"
+    nodes: ["127.0.0.1:8123"]

--- a/docs/content/en/configuration/security.md
+++ b/docs/content/en/configuration/security.md
@@ -13,3 +13,13 @@ By default `chproxy` tries detecting the most obvious configuration errors such 
 
 Special option `hack_me_please: true` may be used for disabling all the security-related checks during config validation (if you are feeling lucky :) ).
 
+For sensitive configuration options, such as user passwords, chproxy supports loading configuration from environment variables. In order to load a configuration variable from a environment variable, a placeholder needs to be put in it's place
+in the configuration file. Placeholder are of the form `${ENV_VAR_NAME}`. As an example, to load a user password from the environment variable `MY_PASSWORD` you can use a placeholder as in the following snippet:
+
+```yaml
+users:
+  - name: "default"
+    password: ${MY_PASSWORD}
+```
+
+This will be replaced by the actual environment variable once the configuration is (re)loaded from disk. If the environment variable isn't found the placeholder will remain and won't be replaced.


### PR DESCRIPTION
## Description

Replace placeholder in configuration of the form "${MY_ENV_VAR}" with the actual environment variable.

Closes #332

<!--  Please explain the object of this PR and the changes you made.
A reference to a github issue would be appreciated. --> 

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [ ] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
