### PR TITLE
chore: Refactor host in scope and seperate to new package topology

### DIFF
--- a/internal/counter/counter.go
+++ b/internal/counter/counter.go
@@ -1,0 +1,15 @@
+package counter
+
+import "sync/atomic"
+
+type Counter struct {
+	value uint32
+}
+
+func (c *Counter) Store(n uint32) { atomic.StoreUint32(&c.value, n) }
+
+func (c *Counter) Load() uint32 { return atomic.LoadUint32(&c.value) }
+
+func (c *Counter) Dec() { atomic.AddUint32(&c.value, ^uint32(0)) }
+
+func (c *Counter) Inc() uint32 { return atomic.AddUint32(&c.value, 1) }

--- a/internal/counter/counter.go
+++ b/internal/counter/counter.go
@@ -3,13 +3,13 @@ package counter
 import "sync/atomic"
 
 type Counter struct {
-	value uint32
+	value atomic.Uint32
 }
 
-func (c *Counter) Store(n uint32) { atomic.StoreUint32(&c.value, n) }
+func (c *Counter) Store(n uint32) { c.value.Store(n) }
 
-func (c *Counter) Load() uint32 { return atomic.LoadUint32(&c.value) }
+func (c *Counter) Load() uint32 { return c.value.Load() }
 
-func (c *Counter) Dec() { atomic.AddUint32(&c.value, ^uint32(0)) }
+func (c *Counter) Dec() { c.value.Add(^uint32(0)) }
 
-func (c *Counter) Inc() uint32 { return atomic.AddUint32(&c.value, 1) }
+func (c *Counter) Inc() uint32 { return c.value.Add(1) }

--- a/internal/topology/main_test.go
+++ b/internal/topology/main_test.go
@@ -1,0 +1,23 @@
+package topology
+
+import (
+	"os"
+	"testing"
+
+	"github.com/contentsquare/chproxy/config"
+)
+
+func TestMain(m *testing.M) {
+	cfg := &config.Config{
+		Server: config.Server{
+			Metrics: config.Metrics{
+				Namespace: "test",
+			},
+		},
+	}
+
+	// Metrics should be preregistered to avoid nil-panics.
+	RegisterMetrics(cfg)
+	code := m.Run()
+	os.Exit(code)
+}

--- a/internal/topology/metrics.go
+++ b/internal/topology/metrics.go
@@ -35,3 +35,27 @@ func RegisterMetrics(cfg *config.Config) {
 	initMetrics(cfg)
 	prometheus.MustRegister(HostHealth, HostPenalties)
 }
+
+func reportNodeHealthMetric(clusterName, replicaName, nodeName string, active bool) {
+	label := prometheus.Labels{
+		"cluster":      clusterName,
+		"replica":      replicaName,
+		"cluster_node": nodeName,
+	}
+
+	if active {
+		HostHealth.With(label).Set(1)
+	} else {
+		HostHealth.With(label).Set(0)
+	}
+}
+
+func incrementPenaltiesMetric(clusterName, replicaName, nodeName string) {
+	label := prometheus.Labels{
+		"cluster":      clusterName,
+		"replica":      replicaName,
+		"cluster_node": nodeName,
+	}
+
+	HostPenalties.With(label).Inc()
+}

--- a/internal/topology/metrics.go
+++ b/internal/topology/metrics.go
@@ -1,0 +1,37 @@
+package topology
+
+// TODO this is only here to avoid recursive imports. We should have a separate package for metrics.
+import (
+	"github.com/contentsquare/chproxy/config"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	HostHealth    *prometheus.GaugeVec
+	HostPenalties *prometheus.CounterVec
+)
+
+func initMetrics(cfg *config.Config) {
+	namespace := cfg.Server.Metrics.Namespace
+	HostHealth = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "host_health",
+			Help:      "Health state of hosts by clusters",
+		},
+		[]string{"cluster", "replica", "cluster_node"},
+	)
+	HostPenalties = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "host_penalties_total",
+			Help:      "Total number of given penalties by host",
+		},
+		[]string{"cluster", "replica", "cluster_node"},
+	)
+}
+
+func RegisterMetrics(cfg *config.Config) {
+	initMetrics(cfg)
+	prometheus.MustRegister(HostHealth, HostPenalties)
+}

--- a/internal/topology/node.go
+++ b/internal/topology/node.go
@@ -1,0 +1,230 @@
+package topology
+
+import (
+	"context"
+	"net/url"
+	"sync/atomic"
+	"time"
+
+	"github.com/contentsquare/chproxy/internal/counter"
+	"github.com/contentsquare/chproxy/internal/heartbeat"
+	"github.com/contentsquare/chproxy/log"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	// prevents excess goroutine creating while penalizing overloaded host
+	DefaultPenaltySize     = 5
+	DefaultMaxSize         = 300
+	DefaultPenaltyDuration = time.Second * 10
+)
+
+type nodeOpts struct {
+	defaultActive   bool
+	penaltySize     uint32
+	penaltyMaxSize  uint32
+	penaltyDuration time.Duration
+}
+
+func defaultNodeOpts() nodeOpts {
+	return nodeOpts{
+		penaltySize:     DefaultPenaltySize,
+		penaltyMaxSize:  DefaultMaxSize,
+		penaltyDuration: DefaultPenaltyDuration,
+	}
+}
+
+type NodeOption interface {
+	apply(*nodeOpts)
+}
+
+type penalty struct {
+	penaltySize     uint32
+	penaltyMaxSize  uint32
+	penaltyDuration time.Duration
+}
+
+func (o penalty) apply(opts *nodeOpts) {
+	opts.penaltySize = o.penaltySize
+	opts.penaltyMaxSize = o.penaltyMaxSize
+	opts.penaltyDuration = o.penaltyDuration
+}
+
+func WithPenalty(size, max uint32, duration time.Duration) NodeOption {
+	return penalty{
+		penaltySize:     size,
+		penaltyMaxSize:  max,
+		penaltyDuration: duration,
+	}
+}
+
+type defaultActive struct {
+	active bool
+}
+
+func (o defaultActive) apply(opts *nodeOpts) {
+	opts.defaultActive = o.active
+}
+
+func WithDefaultActiveState(active bool) NodeOption {
+	return defaultActive{
+		active: active,
+	}
+}
+
+type Node struct {
+	// Node Address.
+	addr *url.URL
+
+	// Whether this node is alive.
+	active atomic.Bool
+
+	// Counter of currently running connections.
+	connections counter.Counter
+
+	// Counter of unsuccesfull request to decrease host priority.
+	penalty atomic.Uint32
+
+	// Heartbeat function
+	hb heartbeat.HeartBeat
+
+	// For metrics only
+	clusterName string
+	replicaName string
+
+	// Additional configuration options
+	opts nodeOpts
+}
+
+func NewNode(addr *url.URL, hb heartbeat.HeartBeat, clusterName, replicaName string, opts ...NodeOption) *Node {
+	nodeOpts := defaultNodeOpts()
+
+	for _, opt := range opts {
+		opt.apply(&nodeOpts)
+	}
+
+	n := &Node{
+		addr:        addr,
+		hb:          hb,
+		clusterName: clusterName,
+		replicaName: replicaName,
+		opts:        nodeOpts,
+	}
+
+	if n.opts.defaultActive {
+		n.SetIsActive(true)
+	}
+
+	return n
+}
+
+func (n *Node) IsActive() bool {
+	return n.active.Load()
+}
+
+func (n *Node) SetIsActive(active bool) {
+	n.active.Store(active)
+}
+
+// StartHeartbeat runs the heartbeat healthcheck against the node
+// until the done channel is closed.
+// If the heartbeat fails, the active status of the node is changed.
+func (n *Node) StartHeartbeat(done <-chan struct{}) {
+	ctx, cancel := context.WithCancel(context.Background())
+	for {
+		n.heartbeat(ctx)
+		select {
+		case <-done:
+			cancel()
+			return
+		case <-time.After(n.hb.Interval()):
+		}
+	}
+}
+
+func (n *Node) heartbeat(ctx context.Context) {
+	label := prometheus.Labels{
+		"cluster":      n.clusterName,
+		"replica":      n.replicaName,
+		"cluster_node": n.Host(),
+	}
+
+	if err := n.hb.IsHealthy(ctx, n.addr.String()); err == nil {
+		n.active.Store(true)
+		HostHealth.With(label).Set(1)
+	} else {
+		log.Errorf("error while health-checking %q host: %s", n.Host(), err)
+		n.active.Store(false)
+		HostHealth.With(label).Set(0)
+	}
+}
+
+// Penalize a node if a request failed to decrease it's priority.
+// If the penalty is already at the maximum allowed size this function
+// will not penalize the node further.
+// A function will be registered to run after the penalty duration to
+// increase the priority again.
+func (n *Node) Penalize() {
+	penalty := n.penalty.Load()
+	if penalty >= n.opts.penaltyMaxSize {
+		return
+	}
+
+	HostPenalties.With(prometheus.Labels{
+		"cluster":      n.clusterName,
+		"replica":      n.replicaName,
+		"cluster_node": n.Host(),
+	}).Inc()
+
+	n.penalty.Add(n.opts.penaltySize)
+
+	time.AfterFunc(n.opts.penaltyDuration, func() {
+		n.penalty.Add(^uint32(n.opts.penaltySize - 1))
+	})
+}
+
+// UnsafeSetPenalty should only be used for testing as it removes the penalty
+// out of control of the node.
+func (n *Node) UnsafeSetPenalty(penalty uint32) {
+	n.penalty.Store(penalty)
+}
+
+// CurrentLoad returns the current node returns the number of open connections
+// plus the penalty.
+func (n *Node) CurrentLoad() uint32 {
+	c := n.connections.Load()
+	p := n.penalty.Load()
+	return c + p
+}
+
+func (n *Node) CurrentConnections() uint32 {
+	return n.connections.Load()
+}
+
+func (n *Node) CurrentPenalty() uint32 {
+	return n.penalty.Load()
+}
+
+func (n *Node) IncrementConnections() {
+	n.connections.Inc()
+}
+
+func (n *Node) DecrementConnections() {
+	n.connections.Dec()
+}
+
+func (n *Node) Scheme() string {
+	return n.addr.Scheme
+}
+
+func (n *Node) Host() string {
+	return n.addr.Host
+}
+
+func (n *Node) ReplicaName() string {
+	return n.replicaName
+}
+
+func (n *Node) String() string {
+	return n.addr.String()
+}

--- a/internal/topology/node_test.go
+++ b/internal/topology/node_test.go
@@ -1,0 +1,84 @@
+package topology
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/contentsquare/chproxy/internal/heartbeat"
+	"github.com/stretchr/testify/assert"
+)
+
+var _ heartbeat.HeartBeat = &mockHeartbeat{}
+
+type mockHeartbeat struct {
+	interval time.Duration
+	err      error
+}
+
+func (hb *mockHeartbeat) Interval() time.Duration {
+	return hb.interval
+}
+
+func (hb *mockHeartbeat) IsHealthy(ctx context.Context, addr string) error {
+	return hb.err
+}
+
+func TestPenalize(t *testing.T) {
+	node := NewNode(&url.URL{Host: "127.0.0.1"}, nil, "test", "test")
+	expectedLoad := uint32(0)
+	assert.Equal(t, expectedLoad, node.CurrentLoad(), "got running queries %d; expected %d", node.CurrentLoad(), expectedLoad)
+
+	node.Penalize()
+	expectedLoad = uint32(DefaultPenaltySize)
+	assert.Equal(t, expectedLoad, node.CurrentLoad(), "got running queries %d; expected %d", node.CurrentLoad(), expectedLoad)
+
+	// do more penalties than `penaltyMaxSize` allows
+	max := int(DefaultMaxSize/DefaultPenaltySize) * 2
+	for i := 0; i < max; i++ {
+		node.Penalize()
+	}
+
+	expectedLoad = uint32(DefaultMaxSize)
+	assert.Equal(t, expectedLoad, node.CurrentLoad(), "got running queries %d; expected %d", node.CurrentLoad(), expectedLoad)
+
+	// Still allow connections to increase.
+	node.IncrementConnections()
+	expectedLoad++
+	assert.Equal(t, expectedLoad, node.CurrentLoad(), "got running queries %d; expected %d", node.CurrentLoad(), expectedLoad)
+}
+
+func TestStartHeartbeat(t *testing.T) {
+	hb := &mockHeartbeat{
+		interval: 100 * time.Millisecond,
+		err:      nil,
+	}
+
+	done := make(chan struct{})
+	defer close(done)
+
+	node := NewNode(&url.URL{Host: "127.0.0.1"}, hb, "test", "test")
+
+	// Node is eventually active after start.
+	go node.StartHeartbeat(done)
+
+	assert.Eventually(t, func() bool {
+		return node.IsActive()
+	}, time.Second, 100*time.Millisecond)
+
+	// change heartbeat to error, node eventually becomes inactive.
+	hb.err = errors.New("failed connection")
+
+	assert.Eventually(t, func() bool {
+		return !node.IsActive()
+	}, time.Second, 100*time.Millisecond)
+
+	// If error is removed node becomes active again.
+	hb.err = nil
+
+	assert.Eventually(t, func() bool {
+		return node.IsActive()
+	}, time.Second, 100*time.Millisecond)
+}

--- a/internal/topology/node_test.go
+++ b/internal/topology/node_test.go
@@ -52,7 +52,7 @@ func TestPenalize(t *testing.T) {
 
 func TestStartHeartbeat(t *testing.T) {
 	hb := &mockHeartbeat{
-		interval: 100 * time.Millisecond,
+		interval: 10 * time.Millisecond,
 		err:      nil,
 	}
 

--- a/metrics.go
+++ b/metrics.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/contentsquare/chproxy/config"
+	"github.com/contentsquare/chproxy/internal/topology"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -10,8 +11,6 @@ var (
 	requestSum                     *prometheus.CounterVec
 	requestSuccess                 *prometheus.CounterVec
 	limitExcess                    *prometheus.CounterVec
-	hostPenalties                  *prometheus.CounterVec
-	hostHealth                     *prometheus.GaugeVec
 	concurrentQueries              *prometheus.GaugeVec
 	requestQueueSize               *prometheus.GaugeVec
 	userQueueOverflow              *prometheus.CounterVec
@@ -72,22 +71,6 @@ func initMetrics(cfg *config.Config) {
 			Help:      "Total number of max_concurrent_queries excess",
 		},
 		[]string{"user", "cluster", "cluster_user", "replica", "cluster_node"},
-	)
-	hostPenalties = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "host_penalties_total",
-			Help:      "Total number of given penalties by host",
-		},
-		[]string{"cluster", "replica", "cluster_node"},
-	)
-	hostHealth = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "host_health",
-			Help:      "Health state of hosts by clusters",
-		},
-		[]string{"cluster", "replica", "cluster_node"},
 	)
 	concurrentQueries = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -287,9 +270,11 @@ func initMetrics(cfg *config.Config) {
 }
 
 func registerMetrics(cfg *config.Config) {
+	topology.RegisterMetrics(cfg)
+
 	initMetrics(cfg)
 	prometheus.MustRegister(statusCodes, requestSum, requestSuccess,
-		limitExcess, hostPenalties, hostHealth, concurrentQueries,
+		limitExcess, concurrentQueries,
 		requestQueueSize, userQueueOverflow, clusterUserQueueOverflow,
 		requestBodyBytes, responseBodyBytes, cacheFailedInsert, cacheCorruptedFetch,
 		cacheHit, cacheMiss, cacheSize, cacheItems, cacheSkipped,

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -95,8 +95,8 @@ func TestNewReverseProxy(t *testing.T) {
 	if len(r.hosts) != 1 {
 		t.Fatalf("got %d hosts; expResponse: %d", len(r.hosts), 1)
 	}
-	if r.hosts[0].addr.Host != "localhost:8123" {
-		t.Fatalf("got %s host; expResponse: %s", r.hosts[0].addr.Host, "localhost:8123")
+	if r.hosts[0].Host() != "localhost:8123" {
+		t.Fatalf("got %s host; expResponse: %s", r.hosts[0].Host(), "localhost:8123")
 	}
 	if len(proxy.users) != 1 {
 		t.Fatalf("got %d users; expResponse: %d", len(proxy.users), 1)

--- a/proxyretry_test.go
+++ b/proxyretry_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/contentsquare/chproxy/internal/topology"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
@@ -156,15 +157,15 @@ func TestQueryWithRetrySuccess(t *testing.T) {
 		t.Errorf("The execution with retry failed, %v", err)
 	}
 	assert.Equal(t, 200, srw.statusCode)
-	assert.Equal(t, 1, int(s.host.counter.load()))
-	assert.Equal(t, 0, int(s.host.penalty))
+	assert.Equal(t, 1, int(s.host.CurrentConnections()))
+	assert.Equal(t, 0, int(s.host.CurrentPenalty()))
 	// should be counter + penalty
-	assert.Equal(t, 1, int(s.host.load()))
+	assert.Equal(t, 1, int(s.host.CurrentLoad()))
 
-	assert.Equal(t, 0, int(erroredHost.counter.load()))
-	assert.Equal(t, penaltySize, int(erroredHost.penalty))
+	assert.Equal(t, 0, int(erroredHost.CurrentConnections()))
+	assert.Equal(t, topology.DefaultPenaltySize, int(erroredHost.CurrentPenalty()))
 	// should be counter + penalty
-	assert.Equal(t, penaltySize, int(erroredHost.load()))
+	assert.Equal(t, topology.DefaultPenaltySize, int(erroredHost.CurrentLoad()))
 
 	assert.Equal(t, mhs.hs, mhs.hst)
 }
@@ -204,7 +205,7 @@ func newHostsCluster(hs []string) *cluster {
 		name: "cluster1",
 	}
 
-	var hosts []*host
+	var hosts []*topology.Node
 
 	replica1 := &replica{
 		cluster:     cluster1,
@@ -219,14 +220,13 @@ func newHostsCluster(hs []string) *cluster {
 			Scheme: "http",
 			Host:   hs[i],
 		}
-		hosti := &host{
-			replica: replica1,
-			penalty: 0,
-			active:  1,
-			addr:    url1,
-		}
+		hosti := topology.NewNode(url1, nil, "", replica1.name)
+		hosti.SetIsActive(true)
+		hosti.UnsafeSetPenalty(1000)
+
 		hosts = append(hosts, hosti)
 	}
+
 	replica1.hosts = hosts
 
 	return cluster1
@@ -235,7 +235,7 @@ func newHostsCluster(hs []string) *cluster {
 func newMockScope(hs []string) *scope {
 	c := newHostsCluster(hs)
 	scopedHost := c.replicas[0].hosts[0]
-	scopedHost.inc()
+	scopedHost.IncrementConnections()
 
 	return &scope{
 		startTime: time.Now(),

--- a/proxyretry_test.go
+++ b/proxyretry_test.go
@@ -222,7 +222,6 @@ func newHostsCluster(hs []string) *cluster {
 		}
 		hosti := topology.NewNode(url1, nil, "", replica1.name)
 		hosti.SetIsActive(true)
-		hosti.UnsafeSetPenalty(1000)
 
 		hosts = append(hosts, hosti)
 	}


### PR DESCRIPTION
## Description

*Motivation:*
Right now a lot of the code base in chproxy resides in a shared main package. This has lead to a lot of coupled code and a code base that is very hard to read.

This PR is a continuation of the work started with the heartbeat to move code away from the main package, decouple the code and improve readability.

*Additions and Changes:*
- Create a new `Node` struct in the new `topology` package that exposes methods from the previous `host` struct. However, it doesn't expose internal state.
- Improve the Node code by using more modern constructs such as `atomic.Bool`.
- Update the scope package and every usage of `host` with `topology.Node`.
- Include a new test case for `Node.StartHeartbeat`

*Notes:*
Due to the coupled nature of the code around scope, I didn't see an opportunity to do this incrementally. The PR will sadly be large and hard to review.

<!--  Please explain the object of this PR and the changes you made.
A reference to a github issue would be appreciated. --> 

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [x] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
