### PR TITLE
fix: uneven load among clickhouse shards caused by retry error mechanism

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -238,8 +238,6 @@ func executeWithRetry(
 		if rw.StatusCode() == http.StatusBadGateway {
 			log.Debugf("the invalid host is: %s", s.host.addr)
 			s.host.penalize()
-			// comment s.host.dec() line to avoid double increment; issue #322
-			// s.host.dec()
 			atomic.StoreUint32(&s.host.active, uint32(0))
 			nextHost := s.host.replica.cluster.getHost()
 			// The query could be retried if it has no stickiness to a certain server
@@ -250,7 +248,7 @@ func executeWithRetry(
 
 				// decrement the current failed host counter and increment the new host
 				// as for the end of the requests we will close the scope and in that closed scope
-				// decrement the new host
+				// decrement the new host PR - https://github.com/ContentSquare/chproxy/pull/357
 				if currentHost != nextHost {
 					currentHost.dec()
 					nextHost.inc()

--- a/proxyretry_test.go
+++ b/proxyretry_test.go
@@ -162,9 +162,9 @@ func TestQueryWithRetrySuccess(t *testing.T) {
 	assert.Equal(t, 1, int(s.host.load()))
 
 	assert.Equal(t, 0, int(erroredHost.counter.load()))
-	assert.Equal(t, 5, int(erroredHost.penalty))
+	assert.Equal(t, penaltySize, int(erroredHost.penalty))
 	// should be counter + penalty
-	assert.Equal(t, 5, int(erroredHost.load()))
+	assert.Equal(t, penaltySize, int(erroredHost.load()))
 
 	assert.Equal(t, mhs.hs, mhs.hst)
 }


### PR DESCRIPTION
## Description


fix uneven load among clickhouse shards caused by the retry error mechanism (related to issues #325 and #322 )

The issue happens when ChProxy sends the HTTP call to one of the shards with a retry mechanism.

When the response from the shard is 502 the [scope's host swaps](https://github.com/ContentSquare/chproxy/blob/6fb82516c6b2066a3a4cd271f22ae741e75b551d/proxy.go#L251) with another one to send by it, which causes not to decreasing the initial host's counter and the new host's counter to decrease instead (when we finally [decrementing the scope](https://github.com/ContentSquare/chproxy/blob/6fb82516c6b2066a3a4cd271f22ae741e75b551d/proxy.go#L107)), which could lead to a situation when the new host's counter is 0 to be set to MaxUint32 value (as `0 - 1` equals to the maximum value of uint32).
once this situation happens the new host will not be able to receive any new requests (as its counter value will be always greater than all other hosts' counter, and the [balancing function logic for getting the new host](https://github.com/ContentSquare/chproxy/blob/6fb82516c6b2066a3a4cd271f22ae741e75b551d/scope.go#L1011) is [based on the host's counter + penalty](https://github.com/ContentSquare/chproxy/blob/6fb82516c6b2066a3a4cd271f22ae741e75b551d/scope.go#L823)) and the host's replica will never be used (same as for the host -> it will always be higher value than all other replicas as we can see in the [getReplica function](https://github.com/ContentSquare/chproxy/blob/6fb82516c6b2066a3a4cd271f22ae741e75b551d/scope.go#L900))


<!--  Please explain the object of this PR and the changes you made.
A reference to a github issue would be appreciated. --> 

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [ ] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
