### PR TITLE
Add db_index option to Redis cache configuration

### DIFF
--- a/clients/redis.go
+++ b/clients/redis.go
@@ -16,6 +16,11 @@ func NewRedisClient(cfg config.RedisCacheConfig) (redis.UniversalClient, error) 
 		MaxRetries: 7, // default value = 3, since MinRetryBackoff = 8 msec & MinRetryBackoff = 512 msec
 		// the redis client will wait up to 1016 msec btw the 7 tries
 	}
+
+	if len(cfg.Addresses) == 1 {
+		options.DB = cfg.DBIndex
+	}
+
 	if len(cfg.CertFile) != 0 || len(cfg.KeyFile) != 0 {
 		tlsConfig, err := cfg.TLS.BuildTLSConfig(nil)
 		if err != nil {

--- a/config/README.md
+++ b/config/README.md
@@ -111,6 +111,7 @@ redis:
     - <string> # example "localhost:6379"
   username: <string>
   password: <string>
+  db_index: <int> | default = 0 [optional]
 
 # Expiration time for cached responses.
 expire: <duration>

--- a/config/README.md
+++ b/config/README.md
@@ -111,7 +111,7 @@ redis:
     - <string> # example "localhost:6379"
   username: <string>
   password: <string>
-  db_index: <int> | default = 0 [optional]
+  db_index: <int> | default = 0 [optional] # This option is only applicable for non-clustered Redis instance.
 
 # Expiration time for cached responses.
 expire: <duration>

--- a/config/config.go
+++ b/config/config.go
@@ -949,6 +949,7 @@ type RedisCacheConfig struct {
 	Username  string                 `yaml:"username,omitempty"`
 	Password  string                 `yaml:"password,omitempty"`
 	Addresses []string               `yaml:"addresses"`
+	DBIndex   int                    `yaml:"db_index,omitempty"`
 	XXX       map[string]interface{} `yaml:",inline"`
 }
 


### PR DESCRIPTION
## Description

This PR introduces the db_index option in the Redis cache configuration for chproxy. The feature allows specifying a particular Redis database index for caching

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [X] Linter passes correctly
- [X] Add tests which fail without the change (if possible)
- [X] All tests passing
- [X] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No
