### PR TITLE
Redis connection loss resiliency

### DIFF
--- a/cache/async_cache_test.go
+++ b/cache/async_cache_test.go
@@ -310,8 +310,8 @@ func TestAsyncCache_RedisCache_wrong_instantiation(t *testing.T) {
 	}
 
 	_, err := NewAsyncCache(redisCfg, 1*time.Second)
-	if err == nil {
-		t.Fatalf("the redis instanciation should have crashed")
+	if err != nil {
+		t.Fatalf("the redis instanciation should not crash")
 	}
 }
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -14,6 +14,7 @@ type Cache interface {
 	Get(key *Key) (*CachedData, error)
 	Put(r io.Reader, ctMetadata ContentMetadata, key *Key) (time.Duration, error)
 	Name() string
+	Alive() bool
 }
 
 type ContentMetadata struct {

--- a/cache/filesystem_cache.go
+++ b/cache/filesystem_cache.go
@@ -86,6 +86,7 @@ func (f *fileSystemCache) Stats() Stats {
 	var s Stats
 	s.Size = atomic.LoadUint64(&f.stats.Size)
 	s.Items = atomic.LoadUint64(&f.stats.Items)
+	s.Alive = 1
 	return s
 }
 

--- a/cache/filesystem_cache.go
+++ b/cache/filesystem_cache.go
@@ -133,6 +133,10 @@ func (f *fileSystemCache) Get(key *Key) (*CachedData, error) {
 	return value, nil
 }
 
+func (f *fileSystemCache) Alive() bool {
+	return true
+}
+
 // decodeHeader decodes header from raw byte stream. Data is encoded as follows:
 // length(contentType)|contentType|length(contentEncoding)|contentEncoding|length(contentLength)|contentLength|cachedData
 func decodeHeader(reader io.Reader) (*ContentMetadata, error) {

--- a/cache/redis_cache.go
+++ b/cache/redis_cache.go
@@ -66,9 +66,14 @@ var usedMemoryRegexp = regexp.MustCompile(`used_memory:([0-9]+)\r\n`)
 // Second one will fetch memory info that will be parsed to fetch the used_memory
 // NOTE : we can only fetch database size, not cache size
 func (r *redisCache) Stats() Stats {
+	alive := uint64(0)
+	if r.alive {
+		alive = 1
+	}
 	return Stats{
 		Items: r.nbOfKeys(),
 		Size:  r.nbOfBytes(),
+		Alive: alive,
 	}
 }
 

--- a/cache/stats.go
+++ b/cache/stats.go
@@ -7,4 +7,6 @@ type Stats struct {
 
 	// Items is the number of items in the cache.
 	Items uint64
+
+	Alive uint64
 }

--- a/clients/redis.go
+++ b/clients/redis.go
@@ -1,9 +1,6 @@
 package clients
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/contentsquare/chproxy/config"
 	"github.com/redis/go-redis/v9"
 )
@@ -29,13 +26,5 @@ func NewRedisClient(cfg config.RedisCacheConfig) (redis.UniversalClient, error) 
 		options.TLSConfig = tlsConfig
 	}
 
-	r := redis.NewUniversalClient(options)
-
-	err := r.Ping(context.Background()).Err()
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to reach redis: %w", err)
-	}
-
-	return r, nil
+	return redis.NewUniversalClient(options), nil
 }

--- a/metrics.go
+++ b/metrics.go
@@ -23,6 +23,7 @@ var (
 	cacheMiss                      *prometheus.CounterVec
 	cacheSize                      *prometheus.GaugeVec
 	cacheItems                     *prometheus.GaugeVec
+	cacheAlive                     *prometheus.GaugeVec
 	cacheSkipped                   *prometheus.CounterVec
 	requestDuration                *prometheus.SummaryVec
 	proxiedResponseDuration        *prometheus.SummaryVec
@@ -168,6 +169,14 @@ func initMetrics(cfg *config.Config) {
 		},
 		[]string{"cache"},
 	)
+	cacheAlive = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "cache_alive",
+			Help:      "Cache alive at the current time",
+		},
+		[]string{"cache"},
+	)
 	cacheSkipped = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: namespace,
@@ -277,7 +286,7 @@ func registerMetrics(cfg *config.Config) {
 		limitExcess, concurrentQueries,
 		requestQueueSize, userQueueOverflow, clusterUserQueueOverflow,
 		requestBodyBytes, responseBodyBytes, cacheFailedInsert, cacheCorruptedFetch,
-		cacheHit, cacheMiss, cacheSize, cacheItems, cacheSkipped,
+		cacheHit, cacheMiss, cacheSize, cacheItems, cacheAlive, cacheSkipped,
 		requestDuration, proxiedResponseDuration, cachedResponseDuration,
 		canceledRequest, timeoutRequest,
 		configSuccess, configSuccessTime, badRequest, retryRequest)

--- a/proxy.go
+++ b/proxy.go
@@ -758,6 +758,7 @@ func (rp *reverseProxy) restartWithNewConfig(caches map[string]*cache.AsyncCache
 	topology.HostHealth.Reset()
 	cacheSize.Reset()
 	cacheItems.Reset()
+	cacheAlive.Reset()
 
 	// Start service goroutines with new configs.
 	for _, c := range clusters {
@@ -799,6 +800,7 @@ func (rp *reverseProxy) refreshCacheMetrics() {
 		}
 		cacheSize.With(labels).Set(float64(stats.Size))
 		cacheItems.With(labels).Set(float64(stats.Items))
+		cacheAlive.With(labels).Set(float64(stats.Alive))
 	}
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -144,7 +144,7 @@ func (rp *reverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if shouldReturnFromCache {
+	if shouldReturnFromCache && s.user.cache.Alive() {
 		rp.serveFromCache(s, srw, req, origParams, q)
 	} else {
 		rp.proxyRequest(s, srw, srw, req)


### PR DESCRIPTION
## Description

Trying to solve this issue: https://github.com/ContentSquare/chproxy/issues/337

Commit by commit:
1. Stop checking redis connectivity at application startup
2. Add a background routine that ping redis and maintain its status
3. Serve requests from cache only when cache is seen as alive
4. Add a cache_alive metric to enable monitoring cache connectivity
5. Update rediscache wrong instantiation test according to 1.

Remark: the method serveFromCache already fallback to proxying requests to Clickhouse (after some time...) in case of error so this PR just add a layer in front of this mechanism.

I did not know what tests to add so feel free to tell me

<!--  Please explain the object of this PR and the changes you made.
A reference to a github issue would be appreciated. --> 

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [x] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
