### PR TITLE
feat: add pool config for redis

### DIFF
--- a/clients/redis.go
+++ b/clients/redis.go
@@ -13,6 +13,7 @@ func NewRedisClient(cfg config.RedisCacheConfig) (redis.UniversalClient, error) 
 		Addrs:      cfg.Addresses,
 		Username:   cfg.Username,
 		Password:   cfg.Password,
+		PoolSize:   cfg.PoolSize,
 		MaxRetries: 7, // default value = 3, since MinRetryBackoff = 8 msec & MinRetryBackoff = 512 msec
 		// the redis client will wait up to 1016 msec btw the 7 tries
 	}

--- a/config/README.md
+++ b/config/README.md
@@ -116,6 +116,7 @@ redis:
     - <string> # example "localhost:6379"
   username: <string>
   password: <string>
+  pool_size: <int>
   db_index: <int> | default = 0 [optional] # This option is only applicable for non-clustered Redis instance.
 
 # Expiration time for cached responses.

--- a/config/config.go
+++ b/config/config.go
@@ -959,6 +959,7 @@ type RedisCacheConfig struct {
 	Password  string                 `yaml:"password,omitempty"`
 	Addresses []string               `yaml:"addresses"`
 	DBIndex   int                    `yaml:"db_index,omitempty"`
+	PoolSize  int                    `yaml:"pool_size,omitempty"`
 	XXX       map[string]interface{} `yaml:",inline"`
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -914,6 +914,7 @@ caches:
     password: XXX
     addresses:
     - 127.0.0.1:%s
+    pool_size: 10
   max_payload_size: 107374182400
   shared_with_all_users: true
 param_groups:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -53,6 +53,7 @@ var fullConfig = Config{
 				Username:  "chproxy",
 				Password:  "password",
 				Addresses: []string{"127.0.0.1:" + redisPort},
+				PoolSize:  10,
 			},
 		},
 	},

--- a/config/testdata/full.yml
+++ b/config/testdata/full.yml
@@ -55,6 +55,7 @@ caches:
     redis:
       username: chproxy
       password: password
+      pool_size: 10
       addresses:
         - 127.0.0.1:16379
     max_payload_size: 107374182400


### PR DESCRIPTION
## Description

add poolsize config for redis.  the default pool size of the go-redis  is small, when many concurrent request to redis, the size of the connection pool affects performance. if the redis pool is full, then all conn in pool is busy, we need to  wait a while.

I think we customize the size according to the requirements.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
