### PR TITLE
Fix `allow_cors: true` returning two `Access-Control-Allow-Origin` headers

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -896,6 +896,59 @@ func TestServe(t *testing.T) {
 			},
 			startHTTP,
 		},
+		{
+			"http allow CORS false",
+			"testdata/http.yml",
+			func(t *testing.T) {
+				req, err := http.NewRequest(http.MethodOptions, "http://127.0.0.1:9090?query=asd", nil)
+				checkErr(t, err)
+				resp, err := http.DefaultClient.Do(req)
+				checkErr(t, err)
+				if resp.StatusCode != http.StatusOK {
+					t.Fatalf("unexpected status code: %d; expected: %d", resp.StatusCode, http.StatusOK)
+				}
+
+				resp.Body.Close()
+				checkHeader(t, resp, "Access-Control-Allow-Origin", "")
+			},
+			startHTTP,
+		},
+		{
+			"http allow CORS true without request Origin header",
+			"testdata/http.allow.cors.yml",
+			func(t *testing.T) {
+				q := "SELECT 123"
+				req, err := http.NewRequest("GET", "http://127.0.0.1:9090?query="+url.QueryEscape(q), nil)
+				checkErr(t, err)
+				resp, err := http.DefaultClient.Do(req)
+				checkErr(t, err)
+				if resp.StatusCode != http.StatusOK {
+					t.Fatalf("unexpected status code: %d; expected: %d", resp.StatusCode, http.StatusOK)
+				}
+				resp.Body.Close()
+				checkHeader(t, resp, "Access-Control-Allow-Origin", "*")
+			},
+			startHTTP,
+		},
+		{
+			"http allow CORS true with request Origin header",
+			"testdata/http.allow.cors.yml",
+			func(t *testing.T) {
+				q := "SELECT 123"
+				req, err := http.NewRequest("GET", "http://127.0.0.1:9090?query="+url.QueryEscape(q), nil)
+				checkErr(t, err)
+				req.Header.Set("Origin", "http://example.com")
+				resp, err := http.DefaultClient.Do(req)
+				checkErr(t, err)
+				if resp.StatusCode != http.StatusOK {
+					t.Fatalf("unexpected status code: %d; expected: %d", resp.StatusCode, http.StatusOK)
+				}
+
+				resp.Body.Close()
+				checkHeader(t, resp, "Access-Control-Allow-Origin", "http://example.com")
+			},
+			startHTTP,
+		},
 	}
 
 	// Wait until CHServer starts.

--- a/main_test.go
+++ b/main_test.go
@@ -900,7 +900,8 @@ func TestServe(t *testing.T) {
 			"http allow CORS false",
 			"testdata/http.yml",
 			func(t *testing.T) {
-				req, err := http.NewRequest(http.MethodOptions, "http://127.0.0.1:9090?query=cors", nil)
+				q := "cors"
+				req, err := http.NewRequest("GET", "http://127.0.0.1:9090?query="+url.QueryEscape(q), nil)
 				checkErr(t, err)
 				resp, err := http.DefaultClient.Do(req)
 				checkErr(t, err)

--- a/main_test.go
+++ b/main_test.go
@@ -909,7 +909,7 @@ func TestServe(t *testing.T) {
 					t.Fatalf("unexpected status code: %d; expected: %d", resp.StatusCode, http.StatusOK)
 				}
 				defer resp.Body.Close()
-				checkHeader(t, resp, "Access-Control-Allow-Origin", "")
+				checkHeader(t, resp, "Access-Control-Allow-Origin", "*")
 			},
 			startHTTP,
 		},

--- a/main_test.go
+++ b/main_test.go
@@ -900,6 +900,8 @@ func TestServe(t *testing.T) {
 			"http allow CORS false",
 			"testdata/http.yml",
 			func(t *testing.T) {
+				// TODO: rework this test because it doesn't fails when it should
+				// cf the discussion in https://github.com/ContentSquare/chproxy/pull/489
 				q := "cors"
 				req, err := http.NewRequest("GET", "http://127.0.0.1:9090?query="+url.QueryEscape(q), nil)
 				checkErr(t, err)
@@ -917,6 +919,8 @@ func TestServe(t *testing.T) {
 			"http allow CORS true without request Origin header",
 			"testdata/http.allow.cors.yml",
 			func(t *testing.T) {
+				// TODO: rework this test because it doesn't fails when it should
+				// cf the discussion in https://github.com/ContentSquare/chproxy/pull/489
 				q := "cors"
 				req, err := http.NewRequest("GET", "http://127.0.0.1:9090?query="+url.QueryEscape(q), nil)
 				checkErr(t, err)
@@ -934,6 +938,8 @@ func TestServe(t *testing.T) {
 			"http allow CORS true with request Origin header",
 			"testdata/http.allow.cors.yml",
 			func(t *testing.T) {
+				// TODO: rework this test because it doesn't fails when it should
+				// cf the discussion in https://github.com/ContentSquare/chproxy/pull/489
 				q := "cors"
 				req, err := http.NewRequest("GET", "http://127.0.0.1:9090?query="+url.QueryEscape(q), nil)
 				checkErr(t, err)

--- a/proxy.go
+++ b/proxy.go
@@ -107,14 +107,6 @@ func (rp *reverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	log.Debugf("%s: request start", s)
 	requestSum.With(s.labels).Inc()
 
-	if s.user.allowCORS {
-		origin := req.Header.Get("Origin")
-		if len(origin) == 0 {
-			origin = "*"
-		}
-		rw.Header().Set("Access-Control-Allow-Origin", origin)
-	}
-
 	req.Body = &statReadCloser{
 		ReadCloser: req.Body,
 		bytesRead:  requestBodyBytes.With(s.labels),
@@ -147,6 +139,14 @@ func (rp *reverseProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		rp.serveFromCache(s, srw, req, origParams, q)
 	} else {
 		rp.proxyRequest(s, srw, srw, req)
+	}
+
+	if s.user.allowCORS {
+		origin := req.Header.Get("Origin")
+		if len(origin) == 0 {
+			origin = "*"
+		}
+		rw.Header().Set("Access-Control-Allow-Origin", origin)
 	}
 
 	// It is safe calling getQuerySnippet here, since the request

--- a/testdata/http.allow.cors.yml
+++ b/testdata/http.allow.cors.yml
@@ -1,0 +1,15 @@
+log_debug: true
+server:
+  http:
+      listen_addr: ":9090"
+      allowed_networks: ["127.0.0.1/24"]
+
+users:
+  - name: "default"
+    to_cluster: "default"
+    to_user: "default"
+    allow_cors: true
+
+clusters:
+  - name: "default"
+    nodes: ["127.0.0.1:18124"]


### PR DESCRIPTION
## Description

<!--  Please explain the object of this PR and the changes you made.
A reference to a github issue would be appreciated. --> 

Fixes #93.
The `Access-Control-Allow-Origin` was set before on the response before the proxy call, and ClickHouse was returning the response with its own `Access-Control-Allow-Origin` (in my case, "*"). So, having `allow_cors: true` was eventually returning two `Access-Control-Allow-Origin`, one from chproxy and one from ClickHouse.

This commit just move the `"Access-Control-Allow-Origin` after the proxy call, overriding the value returned by ClickHouse. If `allow_cors: false`, chproxy does not change the value (so it can be, I believe, any value set by ClickHouse), else, with `allow_cors: true`, it will override to either the value of `Origin` request if any or else `*`.

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [ ] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

The only thing I'm not sure is if we want to pass the initial `Access-Control-Allow-Origin` that was set originally. 
But in my understanding of the feature, the goal is not to add this header to the proxied request to ClickHouse, but rather on the chproxy response. 
