### PR TITLE
fix: avoid useless io in large-payload queries

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -347,7 +347,8 @@ kill_query_user: <kill_query_user_config> | optional
 heartbeat: <heartbeat_config> | optional
 
 # RetryNumber - user configuration for query retry when one host cannot respond.
-# Retry copies the body in POST for reuse, which will impact performance (especially in large-payload insert).
+# By default there are no query retry, because it impacts performance when copying
+# the request body for reuse (especially in large-payload insert).
 retry_number: 0
 
 ```

--- a/config/README.md
+++ b/config/README.md
@@ -347,6 +347,7 @@ kill_query_user: <kill_query_user_config> | optional
 heartbeat: <heartbeat_config> | optional
 
 # RetryNumber - user configuration for query retry when one host cannot respond.
+# Retry copies the body in POST for reuse, which will impact performance (especially in large-payload insert).
 retry_number: 0
 
 ```

--- a/config/README.md
+++ b/config/README.md
@@ -347,8 +347,9 @@ kill_query_user: <kill_query_user_config> | optional
 heartbeat: <heartbeat_config> | optional
 
 # RetryNumber - user configuration for query retry when one host cannot respond.
-# By default there are no query retry, because it impacts performance when copying
-# the request body for reuse (especially in large-payload insert).
+# By default there are no query retries.
+# Note: Retrying may impact performance if there are many large-payload requests (such as inserts),
+# because it requires copying the request body for reuse.
 retry_number: 0
 
 ```

--- a/config/README.md
+++ b/config/README.md
@@ -382,11 +382,11 @@ max_execution_time: <duration> | optional | default = 120s
 # By default there are no per-minute limits
 requests_per_minute: <int> | optional | default = 0
 
-# The burst of request packet size token bucket for user
+# The burst of request packet body size token bucket for user
 # By default there are no request packet size limits
 request_packet_size_tokens_burst: <byte_size> | optional | default = 0
 
-# The request packet size tokens produced rate per second for user
+# The request packet body size tokens produced rate per second for user
 # By default there are no request packet size limits
 request_packet_size_tokens_rate: <byte_size> | optional | default = 0
 

--- a/proxy.go
+++ b/proxy.go
@@ -918,18 +918,5 @@ func (rp *reverseProxy) getScope(req *http.Request) (*scope, int, error) {
 	}
 
 	s := newScope(req, u, c, cu, sessionId, sessionTimeout)
-
-	if s.user.reqPacketSizeTokensBurst > 0 || s.clusterUser.reqPacketSizeTokensBurst > 0 {
-		s.requestPacketSize = int(req.ContentLength)
-		if s.requestPacketSize < 0 {
-			// if ContentLength is unknown, get the length of query
-			q, err := getFullQuery(req)
-			if err != nil {
-				return nil, http.StatusBadRequest, fmt.Errorf("%s: cannot read query: %w", s, err)
-			}
-			s.requestPacketSize = len(q)
-		}
-	}
-
 	return s, 0, nil
 }

--- a/proxy.go
+++ b/proxy.go
@@ -209,7 +209,7 @@ func executeWithRetry(
 	var err error
 	// Use readAndRestoreRequestBody to read the entire request body into a byte slice,
 	// and to restore req.Body so that it can be reused later in the code.
-	if maxRetry > 0 && req.Method == http.MethodPost {
+	if maxRetry > 0 {
 		body, err = readAndRestoreRequestBody(req)
 		if err != nil {
 			since := time.Since(startTime).Seconds()

--- a/proxy.go
+++ b/proxy.go
@@ -205,20 +205,21 @@ func executeWithRetry(
 	startTime := time.Now()
 	var since float64
 
+	var body []byte
+	var err error
 	// Use readAndRestoreRequestBody to read the entire request body into a byte slice,
 	// and to restore req.Body so that it can be reused later in the code.
-	body, err := readAndRestoreRequestBody(req)
-	if err != nil {
-		since := time.Since(startTime).Seconds()
-		return since, err
+	if maxRetry > 0 && req.Method == http.MethodPost {
+		body, err = readAndRestoreRequestBody(req)
+		if err != nil {
+			since := time.Since(startTime).Seconds()
+			return since, err
+		}
 	}
 
 	numRetry := 0
 	for {
 		rp(rw, req)
-
-		// Restore req.Body after it's consumed by 'rp' for potential reuse.
-		req.Body = io.NopCloser(bytes.NewBuffer(body))
 
 		err := ctx.Err()
 		if err != nil {
@@ -269,6 +270,8 @@ func executeWithRetry(
 			since = time.Since(startTime).Seconds()
 			break
 		}
+		// Restore req.Body after it's consumed by 'rp' for potential reuse.
+		req.Body = io.NopCloser(bytes.NewBuffer(body))
 		numRetry++
 	}
 	return since, nil
@@ -916,10 +919,17 @@ func (rp *reverseProxy) getScope(req *http.Request) (*scope, int, error) {
 
 	s := newScope(req, u, c, cu, sessionId, sessionTimeout)
 
-	q, err := getFullQuery(req)
-	if err != nil {
-		return nil, http.StatusBadRequest, fmt.Errorf("%s: cannot read query: %w", s, err)
+	if s.user.reqPacketSizeTokensBurst > 0 || s.clusterUser.reqPacketSizeTokensBurst > 0 {
+		s.requestPacketSize = int(req.ContentLength)
+		if s.requestPacketSize < 0 {
+			// if ContentLength is unknown, get the length of query
+			q, err := getFullQuery(req)
+			if err != nil {
+				return nil, http.StatusBadRequest, fmt.Errorf("%s: cannot read query: %w", s, err)
+			}
+			s.requestPacketSize = len(q)
+		}
 	}
-	s.requestPacketSize = len(q)
+
 	return s, 0, nil
 }

--- a/scope.go
+++ b/scope.go
@@ -86,6 +86,8 @@ func newScope(req *http.Request, u *user, c *cluster, cu *clusterUser, sessionId
 			"replica":      h.ReplicaName(),
 			"cluster_node": h.Host(),
 		},
+
+		requestPacketSize: max(0, int(req.ContentLength)),
 	}
 	return s
 }


### PR DESCRIPTION
## Description

When executing large-payload insert queries by POST, the current retry and throughput-limit mechanisms read the POST body, which can be resource-consuming and may even cause CPU/Memory bottlenecks. This MR avoids unnecessary I/O operations in these two mechanisms:

- For the retry mechanism: If the retry parameter is not set, the step of copying the body can be skipped.
- For the throughput-limit mechanism: Instead of calculating the length of query, the Content-Length is read directly from POST header.

Closes #499, #428 

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Checklist

- [x] Linter passes correctly
- [ ] Add tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Further comments

For the throughput-limit mechanism: The `Content-Length` header indicates the size of the request body, so the throughput of GETs will be ignored. This is logical, as GETs typically have minimal impact on throughput compared to POSTs.
