### PR TITLE
chore: Add multi-arch docker image

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -26,9 +26,9 @@ jobs:
       run: go test -v ./...
 
     - name: Update coverage report
+      if: github.ref == 'refs/heads/master'
       uses: ncruces/go-coverage-report@21fa4b59396f242b81896a3cd212a463589b6742
       with:
         report: 'false'
         chart: 'true'
         amend: 'false'
-

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22
+        go-version-file: go.mod
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
-
-      - name: Install cross-compile package
-        run: |
-          sudo apt update
-          sudo apt install -y gcc gcc-aarch64-linux-gnu musl build-essential
+          go-version-file: go.mod
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 ---
+version: 2
 before:
   hooks:
     - go mod tidy
@@ -27,31 +28,25 @@ builds:
       - -trimpath={{.Env.GOPATH}}/src
 
 dockers:
-  - goos: linux
-    goarch: amd64
-    image_templates:
-      - "contentsquareplatform/chproxy:{{ .Tag }}"
+  - image_templates:
       - "contentsquareplatform/chproxy:{{ .Tag }}-amd64"
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
-#  - goos: linux
-#    goarch: arm64
-#    image_templates:
-#      - "contentsquareplatform/chproxy:{{ .Tag }}-arm64"
-#    use: buildx
-#    build_flag_templates:
-#      - "--platform=linux/arm64"
-#  - goos: linux
-#    goarch: arm64
-#    image_templates:
-#      - "contentsquareplatform/chproxy:{{ .Tag }}-arm64v8"
-#    use: buildx
-#    build_flag_templates:
-#      - "--platform=linux/arm64/v8"
+  - image_templates:
+      - "contentsquareplatform/chproxy:{{ .Tag }}-arm64v8"
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+
+docker_manifests:
+  - name_template: "contentsquareplatform/chproxy:{{ .Tag }}"
+    image_templates:
+      - "contentsquareplatform/chproxy:{{ .Tag }}-amd64"
+      - "contentsquareplatform/chproxy:{{ .Tag }}-arm64v8"
 
 snapshot:
-  name_template: "{{ .FullCommit }}-SNAPSHOT"
+  version_template: "{{ .FullCommit }}-SNAPSHOT"
 
 release:
   # Repo in which the release will be created.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian
+FROM debian:12
 
 RUN apt update && apt install -y ca-certificates curl
 


### PR DESCRIPTION

## Description

Add multi-arch docker image to goreleaser.
This will allow people on ARM system to have native docker image of `chproxy`

Also switch `setup-go` actions to use `go.mod` version to avoid discrepancies


Thanks to @orian for reminding us that we forgot to enable this build
<!--  Please explain the object of this PR and the changes you made.
A reference to a github issue would be appreciated. --> 

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Checklist

- [x] Linter passes correctly
- [x] Add tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Further comments

This was tested on a private fork and separate docker image to make sure it works

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
